### PR TITLE
Support for Unity 2020.1 classes

### DIFF
--- a/AssetRipperCore/ClassIDType.cs
+++ b/AssetRipperCore/ClassIDType.cs
@@ -366,6 +366,7 @@ namespace AssetRipper.Core
 		AssemblyDefinitionReferenceAsset					= 662584278,
 		BuiltAssetBundleInfoSet								= 668709126,
 		SpriteAtlas											= 687078895,
+		LightingSettings                                    = 850595691,
 		PlatformModuleSetup									= 877146078,
 		AimConstraint										= 895512359,
 		VFXManager											= 937362698,
@@ -411,6 +412,7 @@ namespace AssetRipper.Core
 		VisualEffect										= 2083052967,
 		LocalizationAsset									= 2083778819,
 		ScriptedImporter									= 2089858483,
+		
 	}
 
 	public static class ClassIDTypeExtention

--- a/AssetRipperCore/Classes/EdgeCollider2D.cs
+++ b/AssetRipperCore/Classes/EdgeCollider2D.cs
@@ -17,6 +17,11 @@ namespace AssetRipper.Core.Classes
 		/// 5.6.0b5 and greater
 		/// </summary>
 		public static bool HasEdgeRadius(UnityVersion version) => version.IsGreaterEqual(5, 6, 0, UnityVersionType.Beta, 5);
+		
+		/// <summary>
+		/// 2020 and greater
+		/// </summary>
+		public static bool HasAdjacentPoints(UnityVersion version) => version.IsGreaterEqual(2020);
 
 		public override void Read(AssetReader reader)
 		{
@@ -27,6 +32,13 @@ namespace AssetRipper.Core.Classes
 				EdgeRadius = reader.ReadSingle();
 			}
 			Points = reader.ReadAssetArray<Vector2f>();
+			if (HasAdjacentPoints(reader.Version))
+			{
+				AdjacentStartPoint.Read(reader);
+				AdjacentEndPoint.Read(reader);
+				UseAdjacentStartPoint = reader.ReadBoolean();
+				UseAdjacentEndPoint = reader.ReadBoolean();
+			}
 		}
 
 		protected override YAMLMappingNode ExportYAMLRoot(IExportContainer container)
@@ -39,6 +51,14 @@ namespace AssetRipper.Core.Classes
 
 		public float EdgeRadius { get; set; }
 		public Vector2f[] Points { get; set; }
+		
+		public Vector2f AdjacentStartPoint { get; set; }
+		
+		public Vector2f AdjacentEndPoint { get; set; }
+		
+		public bool UseAdjacentStartPoint { get; set; }
+		
+		public bool UseAdjacentEndPoint { get; set; }
 
 		public const string EdgeRadiusName = "m_EdgeRadius";
 		public const string PointsName = "m_Points";

--- a/AssetRipperCore/Classes/GraphicsSettings/GraphicsSettings.cs
+++ b/AssetRipperCore/Classes/GraphicsSettings/GraphicsSettings.cs
@@ -119,6 +119,10 @@ namespace AssetRipper.Core.Classes.GraphicsSettings
 		/// </summary>
 		public static bool HasDepthNormals(UnityVersion version) => version.IsGreaterEqual(5, 4);
 		/// <summary>
+		/// 2020 and greater
+		/// </summary>
+		public static bool HasVideoShadersIncludeMode(UnityVersion version) => version.IsGreaterEqual(2020);
+		/// <summary>
 		/// 4.2.0 and greater
 		/// </summary>
 		public static bool HasAlwaysIncludedShaders(UnityVersion version) => version.IsGreaterEqual(4, 2);
@@ -214,9 +218,9 @@ namespace AssetRipper.Core.Classes.GraphicsSettings
 			return version.IsGreaterEqual(2018, 4, 6);
 		}
 		/// <summary>
-		/// 2019.3 and greater
+		/// 2019.3 and greater but less than 2020
 		/// </summary>
-		public static bool HasAllowEnlightenSupportForUpgradedProject(UnityVersion version) => version.IsGreaterEqual(2019, 3);
+		public static bool HasAllowEnlightenSupportForUpgradedProject(UnityVersion version) => version.IsGreaterEqual(2019, 3) && version.IsLess(2020);
 
 		/// <summary>
 		/// 5.3.0 to 5.5.0 exclusive
@@ -265,6 +269,11 @@ namespace AssetRipper.Core.Classes.GraphicsSettings
 				MotionVectors.Read(reader);
 				LightHalo.Read(reader);
 				LensFlare.Read(reader);
+			}
+
+			if (HasVideoShadersIncludeMode(reader.Version))
+			{
+				VideoShadersIncludeMode = reader.ReadInt32();
 			}
 
 			if (HasAlwaysIncludedShaders(reader.Version))
@@ -832,6 +841,7 @@ namespace AssetRipper.Core.Classes.GraphicsSettings
 		public LightmapStrippingMode LightmapStripping { get; set; }
 		public LightmapStrippingMode FogStripping { get; set; }
 		public InstancingStrippingVariant InstancingStripping { get; set; }
+		public int VideoShadersIncludeMode { get; set; }
 		public bool LightmapKeepPlain { get; set; }
 		public bool LightmapKeepDirCombined { get; set; }
 		public bool LightmapKeepDirSeparate { get; set; }

--- a/AssetRipperCore/Classes/GraphicsSettings/GraphicsSettings.cs
+++ b/AssetRipperCore/Classes/GraphicsSettings/GraphicsSettings.cs
@@ -841,7 +841,6 @@ namespace AssetRipper.Core.Classes.GraphicsSettings
 		public LightmapStrippingMode LightmapStripping { get; set; }
 		public LightmapStrippingMode FogStripping { get; set; }
 		public InstancingStrippingVariant InstancingStripping { get; set; }
-		public int VideoShadersIncludeMode { get; set; }
 		public bool LightmapKeepPlain { get; set; }
 		public bool LightmapKeepDirCombined { get; set; }
 		public bool LightmapKeepDirSeparate { get; set; }
@@ -866,6 +865,8 @@ namespace AssetRipper.Core.Classes.GraphicsSettings
 		public bool LightsUseColorTemperature { get; set; }
 		public bool LogWhenShaderIsCompiled { get; set; }
 		public bool AllowEnlightenSupportForUpgradedProject { get; set; }
+		
+		public int VideoShadersIncludeMode { get; set; }
 
 		public BuiltinShaderSettings Deferred = new();
 		public BuiltinShaderSettings DeferredReflections = new();

--- a/AssetRipperCore/Classes/LightmapSettings/LightingSettings.cs
+++ b/AssetRipperCore/Classes/LightmapSettings/LightingSettings.cs
@@ -1,4 +1,5 @@
 ﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
 using AssetRipper.Core.Layout;
 using AssetRipper.Core.Parser.Asset;
 
@@ -18,10 +19,13 @@ namespace AssetRipper.Core.Classes.LightmapSettings
 			EnableBakedLightmaps = reader.ReadBoolean();
 			EnableRealtimeLightmaps = reader.ReadBoolean();
 			EnableRealtimeEnvironmentLighting = reader.ReadBoolean();
+			reader.AlignStream();
+			
 			BounceScale = reader.ReadSingle();
 			AlbedoBoost = reader.ReadSingle();
 			IndirectOutputScale = reader.ReadSingle();
 			UsingShadowmask = reader.ReadBoolean();
+			reader.AlignStream();
 		}
 
 		public int GIWorkflowMode { get; set; }

--- a/AssetRipperCore/Classes/LightmapSettings/LightingSettings.cs
+++ b/AssetRipperCore/Classes/LightmapSettings/LightingSettings.cs
@@ -1,0 +1,36 @@
+﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Layout;
+using AssetRipper.Core.Parser.Asset;
+
+namespace AssetRipper.Core.Classes.LightmapSettings
+{
+	public class LightingSettings : NamedObject
+	{
+		public LightingSettings(AssetInfo assetInfo) : base(assetInfo)
+		{
+		}
+
+		public override void Read(AssetReader reader)
+		{
+			base.Read(reader);
+
+			GIWorkflowMode = reader.ReadInt32();
+			EnableBakedLightmaps = reader.ReadBoolean();
+			EnableRealtimeLightmaps = reader.ReadBoolean();
+			EnableRealtimeEnvironmentLighting = reader.ReadBoolean();
+			BounceScale = reader.ReadSingle();
+			AlbedoBoost = reader.ReadSingle();
+			IndirectOutputScale = reader.ReadSingle();
+			UsingShadowmask = reader.ReadBoolean();
+		}
+
+		public int GIWorkflowMode { get; set; }
+		public bool EnableBakedLightmaps { get; set; }
+		public bool EnableRealtimeLightmaps { get; set; }
+		public bool EnableRealtimeEnvironmentLighting { get; set; }
+		public float BounceScale { get; set; }
+		public float AlbedoBoost { get; set; }
+		public float IndirectOutputScale { get; set; }
+		public bool UsingShadowmask { get; set; }
+	}
+}

--- a/AssetRipperCore/Classes/LightmapSettings/LightmapSettings.cs
+++ b/AssetRipperCore/Classes/LightmapSettings/LightmapSettings.cs
@@ -171,9 +171,13 @@ namespace AssetRipper.Core.Classes.LightmapSettings
 		/// </summary>
 		public static bool HasRuntimeCPUUsage(UnityVersion version) => version.IsGreaterEqual(5) && version.IsLessEqual(5, 6, 0, UnityVersionType.Beta, 6);
 		/// <summary>
-		/// 5.6.0b2 and greater
+		/// 5.6.0b2 and greater but less than 2020
 		/// </summary>
-		public static bool HasUseShadowmask(UnityVersion version) => version.IsGreaterEqual(5, 6, 0, UnityVersionType.Beta, 2);
+		public static bool HasUseShadowmask(UnityVersion version) => version.IsGreaterEqual(5, 6, 0, UnityVersionType.Beta, 2) && version.IsLess(2020);
+		/// <summary>
+		/// 2020 and greater
+		/// </summary>
+		public static bool HasLightingSettings(UnityVersion version) => version.IsGreaterEqual(2020);
 
 		/// <summary>
 		/// 2017.1 and (Release or Resource)
@@ -271,6 +275,11 @@ namespace AssetRipper.Core.Classes.LightmapSettings
 				{
 					ShadowMaskMode = reader.ReadInt32();
 				}
+			}
+
+			if (HasLightingSettings(reader.Version))
+			{
+				LightingSettings.Read(reader);
 			}
 		}
 
@@ -516,11 +525,13 @@ namespace AssetRipper.Core.Classes.LightmapSettings
 		public ColorSpace BakedColorSpace { get; set; }
 		public bool UseDualLightmapsInForward { get; set; }
 		public int RuntimeCPUUsage { get; set; }
+		public PPtr<LightingSettings> LightingSettings { get; set; }
 		public bool UseShadowmask
 		{
 			get => ShadowMaskMode != 0;
 			set => ShadowMaskMode = value ? 1 : 0;
 		}
+
 		/// <summary>
 		/// 2017.1 - replaced by UseShadowmask
 		/// </summary>

--- a/AssetRipperCore/Classes/MeshRenderer.cs
+++ b/AssetRipperCore/Classes/MeshRenderer.cs
@@ -15,6 +15,9 @@ namespace AssetRipper.Core.Classes
 		/// </summary>
 		public static bool HasVertex(UnityVersion version, TransferInstructionFlags flags) => version.IsGreaterEqual(5) && flags.IsRelease();
 
+		/// <summary>
+		/// 2020 and greater.
+		/// </summary>
 		public static bool HasEnlightenVertexStream(UnityVersion version) => version.IsGreaterEqual(2020);
 
 		public override void Read(AssetReader reader)

--- a/AssetRipperCore/Classes/MeshRenderer.cs
+++ b/AssetRipperCore/Classes/MeshRenderer.cs
@@ -15,6 +15,8 @@ namespace AssetRipper.Core.Classes
 		/// </summary>
 		public static bool HasVertex(UnityVersion version, TransferInstructionFlags flags) => version.IsGreaterEqual(5) && flags.IsRelease();
 
+		public static bool HasEnlightenVertexStream(UnityVersion version) => version.IsGreaterEqual(2020);
+
 		public override void Read(AssetReader reader)
 		{
 			base.Read(reader);
@@ -22,6 +24,11 @@ namespace AssetRipper.Core.Classes
 			if (HasVertex(reader.Version, reader.Flags))
 			{
 				AdditionalVertexStreams.Read(reader);
+			}
+
+			if (HasEnlightenVertexStream(reader.Version))
+			{
+				EnlightenVertexStream.Read(reader);
 			}
 		}
 
@@ -38,5 +45,7 @@ namespace AssetRipper.Core.Classes
 		public const string AdditionalVertexStreamsName = "m_AdditionalVertexStreams";
 
 		public PPtr<Mesh.Mesh> AdditionalVertexStreams;
+		
+		public PPtr<Mesh.Mesh> EnlightenVertexStream;
 	}
 }

--- a/AssetRipperCore/Classes/NavMeshData/NavMeshBuildSettings.cs
+++ b/AssetRipperCore/Classes/NavMeshData/NavMeshBuildSettings.cs
@@ -26,6 +26,8 @@ namespace AssetRipper.Core.Classes.NavMeshData
 			ManualTileSize = 0;
 			TileSize = 256;
 			AccuratePlacement = 0;
+			MaxJobWorkers = 0;
+			PreserveTilesOutsideBounds = 0;
 			Debug = default;
 		}
 
@@ -60,6 +62,10 @@ namespace AssetRipper.Core.Classes.NavMeshData
 		/// 2017.2 and greater
 		/// </summary>
 		public static bool HasDebug(UnityVersion version) => version.IsGreaterEqual(2017, 2);
+		/// <summary>
+		/// 2020 and greater
+		/// </summary>
+		public static bool HasMaxJobWorkersAndPreserveTilesOutsideBounds(UnityVersion version) => version.IsGreaterEqual(2020);
 
 		public void Read(AssetReader reader)
 		{
@@ -99,6 +105,12 @@ namespace AssetRipper.Core.Classes.NavMeshData
 			else
 			{
 				AccuratePlacement = reader.ReadInt32();
+			}
+
+			if (HasMaxJobWorkersAndPreserveTilesOutsideBounds(reader.Version))
+			{
+				MaxJobWorkers = reader.ReadUInt32();
+				PreserveTilesOutsideBounds = reader.ReadInt32();
 			}
 			if (HasDebug(reader.Version))
 			{
@@ -156,6 +168,8 @@ namespace AssetRipper.Core.Classes.NavMeshData
 			set => AccuratePlacement = value ? 1 : 0;
 		}
 		public int AccuratePlacement { get; set; }
+		public uint MaxJobWorkers { get; set; }
+		public int PreserveTilesOutsideBounds { get; set; }
 
 		public const string AgentTypeIDName = "agentTypeID";
 		public const string AgentRadiusName = "agentRadius";

--- a/AssetRipperCore/Classes/ParticleSystemRenderer/ParticleSystemRenderer.cs
+++ b/AssetRipperCore/Classes/ParticleSystemRenderer/ParticleSystemRenderer.cs
@@ -81,6 +81,10 @@ namespace AssetRipper.Core.Classes.ParticleSystemRenderer
 		/// </summary>
 		public static bool HasAllowRoll(UnityVersion version) => version.IsGreaterEqual(2018, 3);
 		/// <summary>
+		/// 2020 and greater
+		/// </summary>
+		public static bool HasStretching(UnityVersion version) => version.IsGreaterEqual(2020);
+		/// <summary>
 		/// 5.5.0 to 5.6.0 exclusive
 		/// </summary>
 		public static bool HasVertexStreamMask(UnityVersion version) => version.IsGreaterEqual(5, 5) && version.IsLess(5, 6);
@@ -168,6 +172,12 @@ namespace AssetRipper.Core.Classes.ParticleSystemRenderer
 				if (HasAllowRoll(reader.Version))
 				{
 					AllowRoll = reader.ReadBoolean();
+				}
+
+				if (HasStretching(reader.Version))
+				{
+					FreeformStretching = reader.ReadBoolean();
+					RotateWithStretchDirection = reader.ReadBoolean();
 				}
 				reader.AlignStream();
 
@@ -269,6 +279,8 @@ namespace AssetRipper.Core.Classes.ParticleSystemRenderer
 		public bool EnableGPUInstancing { get; set; }
 		public bool ApplyActiveColorSpace { get; set; }
 		public bool AllowRoll { get; set; }
+		public bool FreeformStretching { get; set; }
+		public bool RotateWithStretchDirection { get; set; }
 		public byte[] VertexStreams { get; set; }
 		public SpriteMaskInteraction MaskInteraction { get; set; }
 

--- a/AssetRipperCore/Classes/Physics2DSettings/Physics2DSettings.cs
+++ b/AssetRipperCore/Classes/Physics2DSettings/Physics2DSettings.cs
@@ -75,9 +75,13 @@ namespace AssetRipper.Core.Classes.Physics2DSettings
 		/// </summary>
 		public static bool HasJobOptions(UnityVersion version) => version.IsGreaterEqual(2018);
 		/// <summary>
-		/// 2017.1.0b2 and greater
+		/// 2017.1.0b2 and greater but less than 2020
 		/// </summary>
-		public static bool HasAutoSimulation(UnityVersion version) => version.IsGreaterEqual(2017, 1, 0, UnityVersionType.Beta, 2);
+		public static bool HasAutoSimulation(UnityVersion version) => version.IsGreaterEqual(2017, 1, 0, UnityVersionType.Beta, 2) && version.IsLess(2020);
+		/// <summary>
+		/// 2020 and greater
+		/// </summary>
+		public static bool HasSimulationMode(UnityVersion version) => version.IsGreaterEqual(2020);
 		/// <summary>
 		/// 4.6.1 and greater
 		/// </summary>
@@ -155,6 +159,12 @@ namespace AssetRipper.Core.Classes.Physics2DSettings
 			{
 				AutoSimulation = reader.ReadBoolean();
 			}
+
+			if (HasSimulationMode(reader.Version))
+			{
+				SimulationMode = reader.ReadInt32();
+			}
+			
 			QueriesHitTriggers = reader.ReadBoolean();
 			if (HasQueriesStartInColliders(reader.Version))
 			{
@@ -403,6 +413,7 @@ namespace AssetRipper.Core.Classes.Physics2DSettings
 
 		public int VelocityIterations { get; set; }
 		public int PositionIterations { get; set; }
+		public int SimulationMode { get; set; }
 		public float VelocityThreshold { get; set; }
 		public float MaxLinearCorrection { get; set; }
 		public float MaxAngularCorrection { get; set; }

--- a/AssetRipperCore/Classes/PhysicsManager/PhysicsManager.cs
+++ b/AssetRipperCore/Classes/PhysicsManager/PhysicsManager.cs
@@ -67,6 +67,10 @@ namespace AssetRipper.Core.Classes.PhysicsManager
 		}
 
 		/// <summary>
+		/// 2020 and greater
+		/// </summary>
+		public static bool HasDefaultMaxDepenetrationVelocity(UnityVersion version) => version.IsGreaterEqual(2020);
+		/// <summary>
 		/// 5.0.0 and greater
 		/// </summary>
 		public static bool HasSleepThreshold(UnityVersion version) => version.IsGreaterEqual(5);
@@ -155,6 +159,10 @@ namespace AssetRipper.Core.Classes.PhysicsManager
 			Gravity.Read(reader);
 			DefaultMaterial.Read(reader);
 			BounceThreshold = reader.ReadSingle();
+			if (HasDefaultMaxDepenetrationVelocity(reader.Version))
+			{
+				DefaultMaxDepenetrationValue = reader.ReadSingle();
+			}
 			if (HasSleepThreshold(reader.Version))
 			{
 				SleepThreshold = reader.ReadSingle();
@@ -389,6 +397,7 @@ namespace AssetRipper.Core.Classes.PhysicsManager
 		}
 
 		public float BounceThreshold { get; set; }
+		public float DefaultMaxDepenetrationValue { get; set; }
 		public float SleepThreshold { get; set; }
 		public float SleepVelocity { get; set; }
 		public float SleepAngularVelocity { get; set; }

--- a/AssetRipperCore/Classes/PhysicsManager/PhysicsManager.cs
+++ b/AssetRipperCore/Classes/PhysicsManager/PhysicsManager.cs
@@ -161,7 +161,7 @@ namespace AssetRipper.Core.Classes.PhysicsManager
 			BounceThreshold = reader.ReadSingle();
 			if (HasDefaultMaxDepenetrationVelocity(reader.Version))
 			{
-				DefaultMaxDepenetrationValue = reader.ReadSingle();
+				DefaultMaxDepenetrationVelocity = reader.ReadSingle();
 			}
 			if (HasSleepThreshold(reader.Version))
 			{
@@ -397,7 +397,7 @@ namespace AssetRipper.Core.Classes.PhysicsManager
 		}
 
 		public float BounceThreshold { get; set; }
-		public float DefaultMaxDepenetrationValue { get; set; }
+		public float DefaultMaxDepenetrationVelocity { get; set; }
 		public float SleepThreshold { get; set; }
 		public float SleepVelocity { get; set; }
 		public float SleepAngularVelocity { get; set; }

--- a/AssetRipperCore/Classes/Prefab.cs
+++ b/AssetRipperCore/Classes/Prefab.cs
@@ -4,6 +4,7 @@ using AssetRipper.Core.Layout.Classes;
 using AssetRipper.Core.Parser.Asset;
 using AssetRipper.Core.Classes.Misc;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.YAML;
 using System.Collections.Generic;
 
@@ -14,12 +15,22 @@ namespace AssetRipper.Core.Classes
 		public Prefab(AssetLayout layout) : base(layout) { }
 
 		public Prefab(AssetInfo assetInfo) : base(assetInfo) { }
+		
+		/// <summary>
+		/// 2020 and greater
+		/// </summary>
+		public static bool HasHideFlagsBehavior(UnityVersion version) => version.IsGreaterEqual(2020);
 
 		public override void Read(AssetReader reader)
 		{
 			base.Read(reader);
 
 			RootGameObject.Read(reader);
+
+			if (HasHideFlagsBehavior(reader.Version))
+			{
+				HideFlagsBehavior = reader.ReadInt32();
+			}
 		}
 
 		public override void Write(AssetWriter writer)
@@ -27,6 +38,11 @@ namespace AssetRipper.Core.Classes
 			base.Write(writer);
 
 			RootGameObject.Write(writer);
+			
+			if (HasHideFlagsBehavior(writer.Version))
+			{
+				writer.Write(HideFlagsBehavior);
+			}
 		}
 
 		public override IEnumerable<PPtr<Object.Object>> FetchDependencies(DependencyContext context)
@@ -51,5 +67,6 @@ namespace AssetRipper.Core.Classes
 		public override ClassIDType ClassID => ClassIDType.Prefab;
 
 		public PPtr<GameObject.GameObject> RootGameObject;
+		public int HideFlagsBehavior { get; set; }
 	}
 }

--- a/AssetRipperCore/Classes/Renderer/Renderer.cs
+++ b/AssetRipperCore/Classes/Renderer/Renderer.cs
@@ -502,12 +502,6 @@ namespace AssetRipper.Core.Classes.Renderer
 			{
 				reader.AlignStream();
 			}
-
-#warning temp fix for missing 12 bytes until an official struct layout is obtained
-			if (reader.Version.IsGreaterEqual(2020))
-			{
-				reader.ReadBytes(12);
-			}
 		}
 
 		public override IEnumerable<PPtr<Object.Object>> FetchDependencies(DependencyContext context)

--- a/AssetRipperCore/Classes/Texture2D/Texture2D.cs
+++ b/AssetRipperCore/Classes/Texture2D/Texture2D.cs
@@ -283,7 +283,16 @@ namespace AssetRipper.Core.Classes.Texture2D
 			node.AddSerializedVersion(ToSerializedVersion(container.ExportVersion));
 			node.Add(WidthName, Width);
 			node.Add(HeightName, Height);
-			node.Add(CompleteImageSizeName, CompleteImageSize);
+			
+			if(HasUnsignedCompleteImageSize(container.ExportVersion))
+			{
+				node.Add(CompleteImageSizeName,  (uint) CompleteImageSize);
+			}
+			else
+			{
+				node.Add(CompleteImageSizeName,  (int) CompleteImageSize);
+			}
+
 			if (HasMipsStripped(container.ExportVersion))
 			{
 				node.Add(MipsStrippedName, MipsStripped);

--- a/AssetRipperCore/Classes/Texture2D/Texture2D.cs
+++ b/AssetRipperCore/Classes/Texture2D/Texture2D.cs
@@ -36,6 +36,10 @@ namespace AssetRipper.Core.Classes.Texture2D
 		/// <summary>
 		/// 2020 and greater
 		/// </summary>
+		public static bool HasUnsignedCompleteImageSize(UnityVersion version) => version.IsGreaterEqual(2020);
+		/// <summary>
+		/// 2020 and greater
+		/// </summary>
 		public static bool HasMipsStripped(UnityVersion version) => version.IsGreaterEqual(2020);
 		/// <summary>
 		/// Less than 5.2.0
@@ -180,7 +184,7 @@ namespace AssetRipper.Core.Classes.Texture2D
 #endif
 			Width = reader.ReadInt32();
 			Height = reader.ReadInt32();
-			CompleteImageSize = reader.ReadInt32();
+			CompleteImageSize = HasUnsignedCompleteImageSize(reader.Version) ? reader.ReadUInt32() : reader.ReadInt32();
 			if (HasMipsStripped(reader.Version))
 			{
 				var m_MipsStripped = reader.ReadInt32();
@@ -209,13 +213,16 @@ namespace AssetRipper.Core.Classes.Texture2D
 			{
 				IsReadable = reader.ReadBoolean();
 			}
-			if (HasIgnoreMasterTextureLimit(reader.Version))
-			{
-				IgnoreMasterTextureLimit = reader.ReadBoolean();
-			}
+			//NOTE: Original code by Mafaca claims IgnoreMasterTextureLimit comes first, and claims this field is present on 2019.4.9+
+			//AssetStudio, and a structure dump from 2020.1, show it is in this order.
+			//If this breaks, at all, check if it's different for some reason between 2019.4.9 and 2020 full release.
 			if (HasIsPreProcessed(reader.Version))
 			{
 				IsPreProcessed = reader.ReadBoolean();
+			}
+			if (HasIgnoreMasterTextureLimit(reader.Version))
+			{
+				IgnoreMasterTextureLimit = reader.ReadBoolean();
 			}
 			if (HasReadAllowed(reader.Version))
 			{
@@ -350,7 +357,7 @@ namespace AssetRipper.Core.Classes.Texture2D
 
 		public int Width { get; set; }
 		public int Height { get; set; }
-		public int CompleteImageSize { get; set; }
+		public long CompleteImageSize { get; set; }
 		public int MipsStripped { get; set; }
 		public TextureFormat TextureFormat { get; set; }
 		public int MipCount { get; set; }

--- a/AssetRipperCore/Parser/Asset/AssetFactory.cs
+++ b/AssetRipperCore/Parser/Asset/AssetFactory.cs
@@ -326,6 +326,8 @@ namespace AssetRipper.Core.Parser.Asset
 					return new LightmapParameters(assetInfo);
 				case ClassIDType.LightingDataAsset:
 					return new LightingDataAsset(assetInfo);
+				case ClassIDType.LightingSettings:
+					return new LightingSettings(assetInfo);
 
 				case ClassIDType.SpriteAtlas:
 					return new SpriteAtlas(assetInfo);

--- a/AssetRipperCore/Reading/Classes/VideoClip.cs
+++ b/AssetRipperCore/Reading/Classes/VideoClip.cs
@@ -41,6 +41,7 @@ namespace AssetRipper.Core.Reading.Classes
             var m_HasSplitAlpha = reader.ReadBoolean();
             if (version[0] >= 2020) //2020.1 and up
             {
+#warning A type dump from 2019.4 has this field in it, check version gate.
                 var m_sRGB = reader.ReadBoolean();
             }
 


### PR DESCRIPTION
Fixes reading of Renderer-Derived classes by removing the unneeded 12-byte read.
Fixes MeshRenderer specifically by adding EnlightenVertexStream

More to come.