### PR TITLE
WIP: 2020.2 support

### DIFF
--- a/AssetRipperCore/Classes/BuildSettings.cs
+++ b/AssetRipperCore/Classes/BuildSettings.cs
@@ -88,17 +88,17 @@ namespace AssetRipper.Core.Classes
 		/// </summary>
 		public static bool HasAuthToken(UnityVersion version) => version.IsGreaterEqual(3);
 		/// <summary>
-		/// 3.5.0 and greater
+		/// 3.5.0 and greater but less than 2020.2
 		/// </summary>
-		public static bool HasRuntimeClassHashes(UnityVersion version) => version.IsGreaterEqual(3, 5);
+		public static bool HasRuntimeClassHashes(UnityVersion version) => version.IsGreaterEqual(3, 5) && version.IsLess(2020, 2);
 		/// <summary>
 		/// Less than 5.0.0
 		/// </summary>
 		public static bool IsRuntimeClassHashesUInt32(UnityVersion version) => version.IsLess(5);
 		/// <summary>
-		/// 5.0.0 and greater
+		/// 5.0.0 and greater but less than 2020.2
 		/// </summary>
-		public static bool HasScriptHashes(UnityVersion version) => version.IsGreaterEqual(5);
+		public static bool HasScriptHashes(UnityVersion version) => version.IsGreaterEqual(5) && version.IsLess(2020, 2);
 		/// <summary>
 		/// 5.1.0 and greater
 		/// </summary>
@@ -216,6 +216,7 @@ namespace AssetRipper.Core.Classes
 			if (HasScriptHashes(reader.Version))
 			{
 				ScriptHashes = new Dictionary<Hash128, Hash128>();
+				
 				ScriptHashes.Read(reader);
 			}
 			if (HasGraphicsAPIs(reader.Version))

--- a/AssetRipperCore/Classes/EditorSettings/EditorSettings.cs
+++ b/AssetRipperCore/Classes/EditorSettings/EditorSettings.cs
@@ -162,6 +162,10 @@ namespace AssetRipper.Core.Classes.EditorSettings
 		/// </summary>
 		public static bool HasCachingShaderPreprocessor(UnityVersion version) => version.IsGreaterEqual(2020);
 		/// <summary>
+		/// 2020.2 and greater
+		/// </summary>
+		public static bool HasPrefabModeAllowAutoSave(UnityVersion version) => version.IsGreaterEqual(2020, 2);
+		/// <summary>
 		/// 2019.3 and greater
 		/// </summary>
 		public static bool HasEnterPlayModeOptions(UnityVersion version) => version.IsGreaterEqual(2019, 3);
@@ -313,6 +317,11 @@ namespace AssetRipper.Core.Classes.EditorSettings
 			{
 				CachingShaderPreprocessor = reader.ReadBoolean();
 			}
+
+			if (HasPrefabModeAllowAutoSave(reader.Version))
+			{
+				PrefabModeAllowAutoSave = reader.ReadBoolean();
+			}
 			if (IsAlign1(reader.Version))
 			{
 				reader.AlignStream();
@@ -410,6 +419,15 @@ namespace AssetRipper.Core.Classes.EditorSettings
 			{
 				node.Add(AsyncShaderCompilationName, GetAsyncShaderCompilation(container.Version));
 			}
+			if (HasCachingShaderPreprocessor(container.ExportVersion))
+			{
+				node.Add(CachingShaderPreprocessorName, CachingShaderPreprocessor);
+			}
+
+			if (HasPrefabModeAllowAutoSave(container.ExportVersion))
+			{
+				node.Add(PrefabModeAllowAutoSaveName, PrefabModeAllowAutoSave);
+			}
 			if (HasEnterPlayModeOptions(container.ExportVersion))
 			{
 				node.Add(EnterPlayModeOptionsEnabledName, EnterPlayModeOptionsEnabled);
@@ -431,6 +449,12 @@ namespace AssetRipper.Core.Classes.EditorSettings
 				node.Add(CacheServerNamespacePrefixName, GetCacheServerNamespacePrefix(container.Version));
 				node.Add(CacheServerEnableDownloadName, CacheServerEnableDownload);
 				node.Add(CacheServerEnableUploadName, CacheServerEnableUpload);
+
+				if (HasCacheServerAuthAndTls(container.ExportVersion))
+				{
+					node.Add(CacheServerEnableAuthName, CacheServerEnableAuth);
+					node.Add(CacheServerEnableTlsName, CacheServerEnableTls);
+				}
 			}
 			return node;
 		}
@@ -524,6 +548,7 @@ namespace AssetRipper.Core.Classes.EditorSettings
 		public bool EnableTextureStreamingInPlayMode { get; set; }
 		public bool AsyncShaderCompilation { get; set; }
 		public bool CachingShaderPreprocessor { get; set; }
+		public bool PrefabModeAllowAutoSave { get; set; }
 		public bool EnterPlayModeOptionsEnabled { get; set; }
 		public EnterPlayModeOptions EnterPlayModeOptions { get; set; }
 		public int GameObjectNamingDigits { get; set; }
@@ -561,6 +586,8 @@ namespace AssetRipper.Core.Classes.EditorSettings
 		public const string EnableTextureStreamingInEditModeName = "m_EnableTextureStreamingInEditMode";
 		public const string EnableTextureStreamingInPlayModeName = "m_EnableTextureStreamingInPlayMode";
 		public const string AsyncShaderCompilationName = "m_AsyncShaderCompilation";
+		public const string CachingShaderPreprocessorName = "m_CachingShaderPreprocessor";
+		public const string PrefabModeAllowAutoSaveName = "m_PrefabModeAllowAutoSave";
 		public const string EnterPlayModeOptionsEnabledName = "m_EnterPlayModeOptionsEnabled";
 		public const string EnterPlayModeOptionsName = "m_EnterPlayModeOptions";
 		public const string ShowLightmapResolutionOverlayName = "m_ShowLightmapResolutionOverlay";
@@ -571,6 +598,8 @@ namespace AssetRipper.Core.Classes.EditorSettings
 		public const string CacheServerNamespacePrefixName = "m_CacheServerNamespacePrefix";
 		public const string CacheServerEnableDownloadName = "m_CacheServerEnableDownload";
 		public const string CacheServerEnableUploadName = "m_CacheServerEnableUpload";
+		public const string CacheServerEnableAuthName = "m_CacheServerEnableAuth";
+		public const string CacheServerEnableTlsName = "m_CacheServerEnableTls";
 
 		public PPtr<SceneAsset> PrefabRegularEnvironment = new();
 		public PPtr<SceneAsset> PrefabUIEnvironment = new();

--- a/AssetRipperCore/Classes/GraphicsSettings/GraphicsSettings.cs
+++ b/AssetRipperCore/Classes/GraphicsSettings/GraphicsSettings.cs
@@ -223,6 +223,11 @@ namespace AssetRipper.Core.Classes.GraphicsSettings
 		public static bool HasAllowEnlightenSupportForUpgradedProject(UnityVersion version) => version.IsGreaterEqual(2019, 3) && version.IsLess(2020);
 
 		/// <summary>
+		/// 2020.2 and greater
+		/// </summary>
+		public static bool HasDefaultRenderingLayerMask(UnityVersion version) => version.IsGreaterEqual(2020, 2);
+
+		/// <summary>
 		/// 5.3.0 to 5.5.0 exclusive
 		/// </summary>
 		private static bool HasPlatformSettings(UnityVersion version) => version.IsGreaterEqual(5, 3) && version.IsLess(5, 5);
@@ -431,6 +436,12 @@ namespace AssetRipper.Core.Classes.GraphicsSettings
 			{
 				LightsUseLinearIntensity = reader.ReadBoolean();
 				LightsUseColorTemperature = reader.ReadBoolean();
+			}
+
+			if (HasDefaultRenderingLayerMask(reader.Version))
+			{
+				reader.AlignStream();
+				DefaultRenderingLayerMask = reader.ReadInt32();
 			}
 			if (HasLogWhenShaderIsCompiled(reader.Version))
 			{
@@ -863,6 +874,8 @@ namespace AssetRipper.Core.Classes.GraphicsSettings
 		/// LightsUseCCT previously (before 5.6.0b10)
 		/// </summary>
 		public bool LightsUseColorTemperature { get; set; }
+		
+		public int DefaultRenderingLayerMask { get; set; }
 		public bool LogWhenShaderIsCompiled { get; set; }
 		public bool AllowEnlightenSupportForUpgradedProject { get; set; }
 		

--- a/AssetRipperCore/Classes/Light/Light.cs
+++ b/AssetRipperCore/Classes/Light/Light.cs
@@ -137,6 +137,10 @@ namespace AssetRipper.Core.Classes.Light
 		/// </summary>
 		public static bool HasBoundingSphereOverride(UnityVersion version) => version.IsGreaterEqual(2019, 1, 0, UnityVersionType.Beta, 4);
 		/// <summary>
+		/// 2020.2 and greater
+		/// </summary>
+		public static bool HasUseViewFrustumForShadowCasterCull(UnityVersion version) => version.IsGreaterEqual(2020, 2);
+		/// <summary>
 		/// Not Release (NOTE: unknown version)
 		/// </summary>
 		public static bool HasShadowRadius(UnityVersion version, TransferInstructionFlags flags) => !flags.IsRelease();
@@ -246,6 +250,13 @@ namespace AssetRipper.Core.Classes.Light
 			{
 				BoundingSphereOverride.Read(reader);
 				UseBoundingSphereOverride = reader.ReadBoolean();
+				
+				if (HasUseViewFrustumForShadowCasterCull(reader.Version))
+				{
+					//2020.2
+					UseViewFrustumForShadowCasterCull = reader.ReadBoolean();
+				}
+				
 				reader.AlignStream();
 			}
 #if UNIVERSAL
@@ -361,6 +372,7 @@ namespace AssetRipper.Core.Classes.Light
 		public float ColorTemperature { get; set; }
 		public bool UseColorTemperature { get; set; }
 		public bool UseBoundingSphereOverride { get; set; }
+		public bool UseViewFrustumForShadowCasterCull { get; set; }
 #if UNIVERSAL
 		public float ShadowRadius { get; set; }
 		public float ShadowAngle { get; set; }

--- a/AssetRipperCore/Classes/ParticleSystem/Trigger/TriggerModule.cs
+++ b/AssetRipperCore/Classes/ParticleSystem/Trigger/TriggerModule.cs
@@ -2,6 +2,8 @@
 using AssetRipper.Core.Parser.Asset;
 using AssetRipper.Core.Classes.Misc;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.YAML;
 using System.Collections.Generic;
 
@@ -17,47 +19,100 @@ namespace AssetRipper.Core.Classes.ParticleSystem.Trigger
 			RadiusScale = 1.0f;
 		}
 
+		/// <summary>
+		/// Less than 2020.2
+		/// </summary>
+		public static bool HasCollisionShapes(UnityVersion version) => version.IsLess(2020, 2);
+
+		/// <summary>
+		/// At least 2020.2
+		/// </summary>
+		public static bool HasColliderQueryMode(UnityVersion version) => version.IsGreaterEqual(2020, 2);
+
 		public override void Read(AssetReader reader)
 		{
 			base.Read(reader);
 
-			CollisionShape0.Read(reader);
-			CollisionShape1.Read(reader);
-			CollisionShape2.Read(reader);
-			CollisionShape3.Read(reader);
-			CollisionShape4.Read(reader);
-			CollisionShape5.Read(reader);
+			if (HasCollisionShapes(reader.Version))
+			{
+				CollisionShape0.Read(reader);
+				CollisionShape1.Read(reader);
+				CollisionShape2.Read(reader);
+				CollisionShape3.Read(reader);
+				CollisionShape4.Read(reader);
+				CollisionShape5.Read(reader);
+			}
+
 			Inside = (TriggerAction)reader.ReadInt32();
 			Outside = (TriggerAction)reader.ReadInt32();
 			Enter = (TriggerAction)reader.ReadInt32();
 			Exit = (TriggerAction)reader.ReadInt32();
+
+			if (HasColliderQueryMode(reader.Version))
+			{
+				ColliderQueryMode = reader.ReadInt32();
+			}
+
 			RadiusScale = reader.ReadSingle();
+
+			if (!HasCollisionShapes(reader.Version))
+			{
+				Primitives = reader.ReadAssetArray<PPtr<Component>>();
+			}
 		}
 
 		public IEnumerable<PPtr<Object.Object>> FetchDependencies(DependencyContext context)
 		{
-			yield return context.FetchDependency(CollisionShape0, CollisionShape0Name);
-			yield return context.FetchDependency(CollisionShape1, CollisionShape1Name);
-			yield return context.FetchDependency(CollisionShape2, CollisionShape2Name);
-			yield return context.FetchDependency(CollisionShape3, CollisionShape3Name);
-			yield return context.FetchDependency(CollisionShape4, CollisionShape4Name);
-			yield return context.FetchDependency(CollisionShape5, CollisionShape5Name);
+			if (HasCollisionShapes(context.Version))
+			{
+				yield return context.FetchDependency(CollisionShape0, CollisionShape0Name);
+				yield return context.FetchDependency(CollisionShape1, CollisionShape1Name);
+				yield return context.FetchDependency(CollisionShape2, CollisionShape2Name);
+				yield return context.FetchDependency(CollisionShape3, CollisionShape3Name);
+				yield return context.FetchDependency(CollisionShape4, CollisionShape4Name);
+				yield return context.FetchDependency(CollisionShape5, CollisionShape5Name);
+			}
+			else
+			{
+				int i = 0;
+				foreach (PPtr<Component> pPtr in Primitives)
+				{
+					yield return context.FetchDependency(pPtr, $"primitives[{i}]");
+					i++;
+				}
+			}
 		}
 
 		public override YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = (YAMLMappingNode)base.ExportYAML(container);
-			node.Add(CollisionShape0Name, CollisionShape0.ExportYAML(container));
-			node.Add(CollisionShape1Name, CollisionShape1.ExportYAML(container));
-			node.Add(CollisionShape2Name, CollisionShape2.ExportYAML(container));
-			node.Add(CollisionShape3Name, CollisionShape3.ExportYAML(container));
-			node.Add(CollisionShape4Name, CollisionShape4.ExportYAML(container));
-			node.Add(CollisionShape5Name, CollisionShape5.ExportYAML(container));
+			if (HasCollisionShapes(container.ExportVersion))
+			{
+				node.Add(CollisionShape0Name, CollisionShape0.ExportYAML(container));
+				node.Add(CollisionShape1Name, CollisionShape1.ExportYAML(container));
+				node.Add(CollisionShape2Name, CollisionShape2.ExportYAML(container));
+				node.Add(CollisionShape3Name, CollisionShape3.ExportYAML(container));
+				node.Add(CollisionShape4Name, CollisionShape4.ExportYAML(container));
+				node.Add(CollisionShape5Name, CollisionShape5.ExportYAML(container));
+			}
+
 			node.Add(InsideName, (int)Inside);
 			node.Add(OutsideName, (int)Outside);
 			node.Add(EnterName, (int)Enter);
 			node.Add(ExitName, (int)Exit);
+
+			if (HasColliderQueryMode(container.ExportVersion))
+			{
+				node.Add(ColliderQueryModeName, ColliderQueryMode);
+			}
+			
 			node.Add(RadiusScaleName, RadiusScale);
+			
+			if(!HasCollisionShapes(container.ExportVersion))
+			{
+				node.Add(PrimitivesName, Primitives.ExportYAML(container));
+			}
+			
 			return node;
 		}
 
@@ -65,7 +120,9 @@ namespace AssetRipper.Core.Classes.ParticleSystem.Trigger
 		public TriggerAction Outside { get; set; }
 		public TriggerAction Enter { get; set; }
 		public TriggerAction Exit { get; set; }
+		public int ColliderQueryMode { get; set; }
 		public float RadiusScale { get; set; }
+		public PPtr<Component>[] Primitives { get; set; }
 
 		public const string CollisionShape0Name = "collisionShape0";
 		public const string CollisionShape1Name = "collisionShape1";
@@ -73,10 +130,12 @@ namespace AssetRipper.Core.Classes.ParticleSystem.Trigger
 		public const string CollisionShape3Name = "collisionShape3";
 		public const string CollisionShape4Name = "collisionShape4";
 		public const string CollisionShape5Name = "collisionShape5";
+		public const string PrimitivesName = "primitives";
 		public const string InsideName = "inside";
 		public const string OutsideName = "outside";
 		public const string EnterName = "enter";
 		public const string ExitName = "exit";
+		public const string ColliderQueryModeName = "colliderQueryMode";
 		public const string RadiusScaleName = "radiusScale";
 
 		public PPtr<Component> CollisionShape0;

--- a/AssetRipperCore/Classes/Physics2DSettings/Physics2DSettings.cs
+++ b/AssetRipperCore/Classes/Physics2DSettings/Physics2DSettings.cs
@@ -99,6 +99,11 @@ namespace AssetRipper.Core.Classes.Physics2DSettings
 		/// </summary>
 		public static bool HasCallbacksOnDisable(UnityVersion version) => version.IsGreaterEqual(5, 6, 0, UnityVersionType.Patch);
 		/// <summary>
+		/// At least 2019.4 and later.
+		/// </summary>
+#warning This might be present in earlier versions. Check.
+		public static bool HasReuseCollisionCallbacks(UnityVersion version) => version.IsGreaterEqual(2019, 4);
+		/// <summary>
 		/// 2017.2 and greater
 		/// </summary>
 		public static bool HasAutoSyncTransforms(UnityVersion version) => version.IsGreaterEqual(2017, 2);
@@ -181,6 +186,11 @@ namespace AssetRipper.Core.Classes.Physics2DSettings
 			if (HasCallbacksOnDisable(reader.Version))
 			{
 				CallbacksOnDisable = reader.ReadBoolean();
+			}
+			if (HasReuseCollisionCallbacks(reader.Version))
+			{
+#warning This might be present prior to 2019.4. Check. 
+				ReuseCollisionCallbacks = reader.ReadBoolean();
 			}
 			if (HasAutoSyncTransforms(reader.Version))
 			{
@@ -438,6 +448,8 @@ namespace AssetRipper.Core.Classes.Physics2DSettings
 		public bool DeleteStopsCallbacks { get; set; }
 		public bool ChangeStopsCallbacks { get; set; }
 		public bool CallbacksOnDisable { get; set; }
+		
+		public bool ReuseCollisionCallbacks { get; set; }
 		public bool AutoSyncTransforms { get; set; }
 #if UNIVERSAL
 		public bool AlwaysShowColliders { get; set; }

--- a/AssetRipperCore/Classes/TerrainData/DetailDatabase.cs
+++ b/AssetRipperCore/Classes/TerrainData/DetailDatabase.cs
@@ -38,6 +38,10 @@ namespace AssetRipper.Core.Classes.TerrainData
 		/// 2019.1.0b6 and greater
 		/// </summary>
 		public static bool HasDetailBillboardShader(UnityVersion version) => version.IsGreaterEqual(2019, 1, 0, UnityVersionType.Beta, 6);
+		/// <summary>
+		/// Less than 2020.2
+		/// </summary>
+		public static bool HasRandomRotations(UnityVersion version) => version.IsLess(2020, 2);
 
 		public DetailDatabase Convert(IExportContainer container)
 		{
@@ -50,7 +54,11 @@ namespace AssetRipper.Core.Classes.TerrainData
 			DetailPrototypes = reader.ReadAssetArray<DetailPrototype>();
 			PatchCount = reader.ReadInt32();
 			PatchSamples = reader.ReadInt32();
-			RandomRotations = reader.ReadAssetArray<Vector3f>();
+			if (HasRandomRotations(reader.Version))
+			{
+				RandomRotations = reader.ReadAssetArray<Vector3f>();
+			}
+
 			if (HasAtlasTexture(reader.Version))
 			{
 				AtlasTexture.Read(reader);
@@ -80,7 +88,11 @@ namespace AssetRipper.Core.Classes.TerrainData
 			DetailPrototypes.Write(writer);
 			writer.Write(PatchCount);
 			writer.Write(PatchSamples);
-			RandomRotations.Write(writer);
+			if (HasRandomRotations(writer.Version))
+			{
+				RandomRotations.Write(writer);
+			}
+
 			if (HasAtlasTexture(writer.Version))
 			{
 				AtlasTexture.Write(writer);
@@ -112,7 +124,11 @@ namespace AssetRipper.Core.Classes.TerrainData
 			node.Add(DetailPrototypesName, DetailPrototypes.ExportYAML(container));
 			node.Add(PatchCountName, PatchCount);
 			node.Add(PatchSamplesName, PatchSamples);
-			node.Add(RandomRotationsName, RandomRotations.ExportYAML(container));
+			if (HasRandomRotations(container.ExportVersion))
+			{
+				node.Add(RandomRotationsName, RandomRotations.ExportYAML(container));
+			}
+
 			if (HasAtlasTexture(container.ExportVersion))
 			{
 				node.Add(AtlasTextureName, AtlasTexture.ExportYAML(container));

--- a/AssetRipperCore/Classes/TerrainData/DetailPatch.cs
+++ b/AssetRipperCore/Classes/TerrainData/DetailPatch.cs
@@ -2,6 +2,7 @@ using AssetRipper.Core.Project;
 using AssetRipper.Core.Classes.Misc.Serializable;
 using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.YAML;
 using AssetRipper.Core.YAML.Extensions;
 
@@ -9,9 +10,17 @@ namespace AssetRipper.Core.Classes.TerrainData
 {
 	public struct DetailPatch : IAsset
 	{
+		/// <summary>
+		/// Less than 2020.2
+		/// </summary>
+		public static bool HasBounds(UnityVersion version) => version.IsLess(2020, 2);
 		public void Read(AssetReader reader)
 		{
-			Bounds.Read(reader);
+			if (HasBounds(reader.Version))
+			{
+				Bounds.Read(reader);
+			}
+
 			LayerIndices = reader.ReadByteArray();
 			reader.AlignStream();
 			NumberOfObjects = reader.ReadByteArray();
@@ -20,7 +29,11 @@ namespace AssetRipper.Core.Classes.TerrainData
 
 		public void Write(AssetWriter writer)
 		{
-			Bounds.Write(writer);
+			if (HasBounds(writer.Version))
+			{
+				Bounds.Write(writer);
+			}
+
 			LayerIndices.Write(writer);
 			writer.AlignStream();
 			NumberOfObjects.Write(writer);
@@ -30,7 +43,11 @@ namespace AssetRipper.Core.Classes.TerrainData
 		public YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
-			node.Add(BoundsName, Bounds.ExportYAML(container));
+			if (HasBounds(container.ExportVersion))
+			{
+				node.Add(BoundsName, Bounds.ExportYAML(container));
+			}
+
 			node.Add(LayerIndicesName, LayerIndices.ExportYAML());
 			node.Add(NumberOfObjectsName, NumberOfObjects.ExportYAML());
 			return node;

--- a/AssetRipperCore/Classes/TerrainData/DetailPrototype.cs
+++ b/AssetRipperCore/Classes/TerrainData/DetailPrototype.cs
@@ -24,6 +24,11 @@ namespace AssetRipper.Core.Classes.TerrainData
 		/// </summary>
 		public static bool HasGrayscaleLighting(UnityVersion version) => version.IsLess(3);
 
+		/// <summary>
+		/// At least 2020.2
+		/// </summary>
+		public static bool HasHoleTestRadiusInsteadOfBendFactor(UnityVersion version) => version.IsGreaterEqual(2020, 2);
+
 		public void Read(AssetReader reader)
 		{
 			Prototype.Read(reader);
@@ -33,7 +38,15 @@ namespace AssetRipper.Core.Classes.TerrainData
 			MinHeight = reader.ReadSingle();
 			MaxHeight = reader.ReadSingle();
 			NoiseSpread = reader.ReadSingle();
-			BendFactor = reader.ReadSingle();
+			if (HasHoleTestRadiusInsteadOfBendFactor(reader.Version))
+			{
+				HoleTestRadius = reader.ReadSingle();
+			}
+			else
+			{
+				BendFactor = reader.ReadSingle();
+			}
+
 			HealthyColor.Read(reader);
 			DryColor.Read(reader);
 			if (HasGrayscaleLighting(reader.Version))
@@ -54,8 +67,16 @@ namespace AssetRipper.Core.Classes.TerrainData
 			writer.Write(MinHeight);
 			writer.Write(MaxHeight);
 			writer.Write(NoiseSpread);
-			writer.Write(BendFactor);
-			writer.Write(BendFactor);
+			if (HasHoleTestRadiusInsteadOfBendFactor(writer.Version))
+			{
+				writer.Write(HoleTestRadius);
+			}
+			else
+			{
+				writer.Write(BendFactor);
+			}
+
+			// writer.Write(BendFactor);
 			HealthyColor.Write(writer);
 			DryColor.Write(writer);
 			if (HasGrayscaleLighting(writer.Version))
@@ -84,7 +105,15 @@ namespace AssetRipper.Core.Classes.TerrainData
 			node.Add(MinHeightName, MinHeight);
 			node.Add(MaxHeightName, MaxHeight);
 			node.Add(NoiseSpreadName, NoiseSpread);
-			node.Add(BendFactorName, BendFactor);
+			if (HasHoleTestRadiusInsteadOfBendFactor(container.ExportVersion))
+			{
+				node.Add(BendFactorName, HoleTestRadius);
+			}
+			else
+			{
+				node.Add(BendFactorName, BendFactor);
+			}
+
 			node.Add(HealthyColorName, HealthyColor.ExportYAML(container));
 			node.Add(DryColorName, DryColor.ExportYAML(container));
 			if (HasGrayscaleLighting(container.ExportVersion))
@@ -103,6 +132,7 @@ namespace AssetRipper.Core.Classes.TerrainData
 		public float MaxHeight { get; set; }
 		public float NoiseSpread { get; set; }
 		public float BendFactor { get; set; }
+		public float HoleTestRadius { get; set; }
 		public int GrayscaleLighting { get; set; }
 		public float LightmapFactor { get; set; }
 		public DetailRenderMode RenderMode { get; set; }
@@ -116,6 +146,7 @@ namespace AssetRipper.Core.Classes.TerrainData
 		public const string MaxHeightName = "maxHeight";
 		public const string NoiseSpreadName = "noiseSpread";
 		public const string BendFactorName = "bendFactor";
+		public const string HoleTestRadiusName = "holeTestRadius";
 		public const string HealthyColorName = "healthyColor";
 		public const string DryColorName = "dryColor";
 		public const string GrayscaleLightingName = "grayscaleLighting";

--- a/AssetRipperCore/Classes/TerrainData/TreePrototype.cs
+++ b/AssetRipperCore/Classes/TerrainData/TreePrototype.cs
@@ -2,6 +2,7 @@ using AssetRipper.Core.Project;
 using AssetRipper.Core.Parser.Asset;
 using AssetRipper.Core.Classes.Misc;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.YAML;
 using System.Collections.Generic;
 
@@ -9,16 +10,30 @@ namespace AssetRipper.Core.Classes.TerrainData
 {
 	public struct TreePrototype : IAsset, IDependent
 	{
+		
+		/// <summary>
+		/// 2020.2 and greater
+		/// </summary>
+		public static bool HasNavMeshLod(UnityVersion version) => version.IsGreaterEqual(2020, 2);
+		
 		public void Read(AssetReader reader)
 		{
 			Prefab.Read(reader);
 			BendFactor = reader.ReadSingle();
+			if (HasNavMeshLod(reader.Version))
+			{
+				NavMeshLod = reader.ReadInt32();
+			}
 		}
 
 		public void Write(AssetWriter writer)
 		{
 			Prefab.Write(writer);
 			writer.Write(BendFactor);
+			if (HasNavMeshLod(writer.Version))
+			{
+				writer.Write(NavMeshLod);
+			}
 		}
 
 		public IEnumerable<PPtr<Object.Object>> FetchDependencies(DependencyContext context)
@@ -31,13 +46,19 @@ namespace AssetRipper.Core.Classes.TerrainData
 			YAMLMappingNode node = new YAMLMappingNode();
 			node.Add(PrefabName, Prefab.ExportYAML(container));
 			node.Add(BendFactorName, BendFactor);
+			if (HasNavMeshLod(container.ExportVersion))
+			{
+				node.Add(NavMeshLodName, NavMeshLod);
+			}
 			return node;
 		}
 
 		public float BendFactor { get; set; }
+		public float NavMeshLod { get; set; }
 
 		public const string PrefabName = "prefab";
 		public const string BendFactorName = "bendFactor";
+		public const string NavMeshLodName = "navMeshLod";
 
 		public PPtr<GameObject.GameObject> Prefab;
 	}

--- a/AssetRipperCore/Classes/Texture3D.cs
+++ b/AssetRipperCore/Classes/Texture3D.cs
@@ -36,6 +36,10 @@ namespace AssetRipper.Core.Classes
 		/// </summary>
 		public static bool HasDepth(UnityVersion version) => version.IsGreaterEqual(4);
 		/// <summary>
+		/// 2020.2 and greater
+		/// </summary>
+		public static bool HasUsageMode(UnityVersion version) => version.IsGreaterEqual(2020, 2);
+		/// <summary>
 		/// 2.6.0 to 4.0.0 exclusize or 5.4.0 and greater
 		/// </summary>
 		public static bool HasIsReadable(UnityVersion version) => IsReadableFirst(version) || IsReadableSecond(version);
@@ -158,6 +162,11 @@ namespace AssetRipper.Core.Classes
 			}
 			TextureSettings.Read(reader);
 
+			if (HasUsageMode(reader.Version))
+			{
+				UsageMode = reader.ReadInt32();
+			}
+
 			if (IsReadableSecond(reader.Version))
 			{
 				IsReadable = reader.ReadBoolean();
@@ -197,6 +206,10 @@ namespace AssetRipper.Core.Classes
 			node.Add(MipCountName, MipCount);
 			node.Add(DataSizeName, DataSize);
 			node.Add(TextureSettingsName, TextureSettings.ExportYAML(container));
+			if (HasUsageMode(container.ExportVersion))
+			{
+				node.Add(UsageModeName, UsageMode);
+			}
 			node.Add(IsReadableName, IsReadable);
 			byte[] imageData = GetImageData(container.Version);
 			node.Add(ImageDataName, imageData.Length);
@@ -241,6 +254,7 @@ namespace AssetRipper.Core.Classes
 		/// </summary>
 		public int MipCount { get; set; }
 		public int ImageCount { get; set; }
+		public int UsageMode { get; set; }
 		public TextureDimension TextureDimension { get; set; }
 		public TextureUsageMode LightmapFormat { get; set; }
 		public IReadOnlyCollection<byte> ImageData => m_imageData;
@@ -254,6 +268,7 @@ namespace AssetRipper.Core.Classes
 		public const string TextureFormatName = "m_TextureFormat";
 		public const string MipMapName = "m_MipMap";
 		public const string MipCountName = "m_MipCount";
+		public const string UsageModeName = "m_UsageMode";
 		public const string IsReadableName = "m_IsReadable";
 		public const string DataSizeName = "m_DataSize";
 		public const string ImageCountName = "m_ImageCount";

--- a/AssetRipperCore/IO/Extensions/IDictionaryReadAssetExtensions.cs
+++ b/AssetRipperCore/IO/Extensions/IDictionaryReadAssetExtensions.cs
@@ -134,6 +134,18 @@ namespace AssetRipper.Core.IO.Extensions
 				_this.Add(key, value);
 			}
 		}
+		
+		public static void Read<T>(this IDictionary<uint, T> _this, AssetReader reader) where T : IAssetReadable, new()
+		{
+			int count = reader.ReadInt32();
+			for (int i = 0; i < count; i++)
+			{
+				uint key = reader.ReadUInt32();
+				T value = new T();
+				value.Read(reader);
+				_this.Add(key, value);
+			}
+		}
 
 		public static void Read<T>(this IDictionary<string, T> _this, AssetReader reader) where T : IAssetReadable, new()
 		{

--- a/AssetRipperCore/Project/ProjectExporter.cs
+++ b/AssetRipperCore/Project/ProjectExporter.cs
@@ -142,6 +142,7 @@ namespace AssetRipper.Core.Project
 			OverrideYamlExporter(ClassIDType.LightmapParameters);
 			OverrideYamlExporter(ClassIDType.SpriteAtlas);
 			OverrideYamlExporter(ClassIDType.TerrainLayer);
+			OverrideYamlExporter(ClassIDType.LightingSettings);
 
 			OverrideBinaryExporter(ClassIDType.Shader);
 			OverrideBinaryExporter(ClassIDType.AudioClip);


### PR DESCRIPTION
Update structs so that unity 2020.2 games can load. 
Exporting currently throws due to a failure with shaders:
```
Error message: Unable to decode SMOL-V shader

Stack trace:    at AssetRipper.Library.Exporters.Shaders.ShaderVulkanExporter.ExportSnippet(TextWriter writer, Stream stream, Int32 offset, Int32 size) in E:\Projects\AssetRipper\AssetRipperLibrary\Exporters\Shaders\ShaderVulkanExporter.cs:line 57
   at AssetRipper.Library.Exporters.Shaders.ShaderVulkanExporter.Export(ShaderWriter writer, ShaderSubProgram& subProgram) in E:\Projects\AssetRipper\AssetRipperLibrary\Exporters\Shaders\ShaderVulkanExporter.cs:line 30
   at AssetRipper.Core.IO.ShaderWriter.WriteShaderData(ShaderSubProgram& subProgram) in E:\Projects\AssetRipper\AssetRipperCore\IO\ShaderWriter.cs:line 35
   at AssetRipper.Core.Classes.Shader.ShaderSubProgram.Export(ShaderWriter writer, ShaderType type) in E:\Projects\AssetRipper\AssetRipperCore\Classes\Shader\ShaderSubProgram.cs:line 342
   at AssetRipper.Core.Classes.Shader.SerializedShader.SerializedSubProgram.Export(ShaderWriter writer, ShaderType type, Boolean isTier) in E:\Projects\AssetRipper\AssetRipperCore\Classes\Shader\SerializedShader\SerializedSubProgram.cs:line 131
   at AssetRipper.Core.Classes.Shader.SerializedShader.SerializedProgram.Export(ShaderWriter writer, ShaderType type) in E:\Projects\AssetRipper\AssetRipperCore\Classes\Shader\SerializedShader\SerializedProgram.cs:line 36
   at AssetRipper.Core.Classes.Shader.SerializedShader.SerializedPass.Export(ShaderWriter writer) in E:\Projects\AssetRipper\AssetRipperCore\Classes\Shader\SerializedShader\SerializedPass.cs:line 90
   at AssetRipper.Core.Classes.Shader.SerializedShader.SerializedSubShader.Export(ShaderWriter writer) in E:\Projects\AssetRipper\AssetRipperCore\Classes\Shader\SerializedShader\SerializedSubShader.cs:line 26
```

Also includes a fix for exporting LightingSettings (default YAML export, needs an implementation eventually), and a fix for Graphics2DSettings not loading correctly in 2020.1, despite that version's changes being implemented, due to a missing boolean previously.