### PR TITLE
Add basic asset viewer to GUI

### DIFF
--- a/AssetRipperCore/Project/ProjectAssetContainer.cs
+++ b/AssetRipperCore/Project/ProjectAssetContainer.cs
@@ -98,7 +98,7 @@ namespace AssetRipper.Core.Project
 			return File.GetAsset(pathID);
 		}
 
-		public Object FindAsset(int fileIndex, long pathID)
+		public virtual Object FindAsset(int fileIndex, long pathID)
 		{
 			if (fileIndex == VirtualSerializedFile.VirtualFileIndex)
 			{
@@ -110,7 +110,7 @@ namespace AssetRipper.Core.Project
 			}
 		}
 
-		public Object GetAsset(int fileIndex, long pathID)
+		public virtual Object GetAsset(int fileIndex, long pathID)
 		{
 			if (fileIndex == VirtualSerializedFile.VirtualFileIndex)
 			{
@@ -127,7 +127,7 @@ namespace AssetRipper.Core.Project
 			return File.FindAsset(classID);
 		}
 
-		public Object FindAsset(ClassIDType classID, string name)
+		public virtual Object FindAsset(ClassIDType classID, string name)
 		{
 			return File.FindAsset(classID, name);
 		}
@@ -359,7 +359,7 @@ namespace AssetRipper.Core.Project
 
 		public IExportCollection CurrentCollection { get; set; }
 		public VirtualSerializedFile VirtualFile { get; }
-		public ISerializedFile File => CurrentCollection.File;
+		public virtual ISerializedFile File => CurrentCollection.File;
 		public string Name => File.Name;
 		public AssetLayout Layout => File.Layout;
 		public UnityVersion Version => File.Version;
@@ -368,8 +368,8 @@ namespace AssetRipper.Core.Project
 		public AssetLayout ExportLayout { get; }
 		public UnityVersion ExportVersion => ExportLayout.Info.Version;
 		public Platform ExportPlatform => ExportLayout.Info.Platform;
-		public TransferInstructionFlags ExportFlags => ExportLayout.Info.Flags | CurrentCollection.Flags;
-		public IReadOnlyList<FileIdentifier> Dependencies => File.Dependencies;
+		public virtual TransferInstructionFlags ExportFlags => ExportLayout.Info.Flags | CurrentCollection.Flags;
+		public virtual IReadOnlyList<FileIdentifier> Dependencies => File.Dependencies;
 
 		private const string ResourceKeyword = "Resources";
 		private const string AssetBundleKeyword = "AssetBundles";

--- a/AssetRipperCore/YAML/YAMLMappingNode.cs
+++ b/AssetRipperCore/YAML/YAMLMappingNode.cs
@@ -323,6 +323,6 @@ namespace AssetRipper.Core.YAML
 
 		public MappingStyle Style { get; set; }
 
-		private readonly List<KeyValuePair<YAMLNode, YAMLNode>> m_children = new List<KeyValuePair<YAMLNode, YAMLNode>>();
+		public readonly List<KeyValuePair<YAMLNode, YAMLNode>> m_children = new List<KeyValuePair<YAMLNode, YAMLNode>>();
 	}
 }

--- a/AssetRipperCore/YAML/YAMLSequenceNode.cs
+++ b/AssetRipperCore/YAML/YAMLSequenceNode.cs
@@ -206,6 +206,6 @@ namespace AssetRipper.Core.YAML
 
 		public SequenceStyle Style { get; }
 
-		private readonly List<YAMLNode> m_children = new List<YAMLNode>();
+		public readonly List<YAMLNode> m_children = new List<YAMLNode>();
 	}
 }

--- a/AssetRipperGUI/AssetInfo/AssetYamlNode.cs
+++ b/AssetRipperGUI/AssetInfo/AssetYamlNode.cs
@@ -1,0 +1,95 @@
+﻿using AssetRipper.Core.YAML;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AssetRipper.GUI.AssetInfo
+{
+	public class AssetYamlNode
+	{
+		//Nodes can be either key-value (YamlScalarNode) or object (YamlMappingNode)/array (YamlSequenceNode).
+		//If key-value, display name is "key: value"
+		//If object/array, display name is "key", nested children are array elements.
+		
+		public string DisplayName { get; }
+		public List<AssetYamlNode> Children { get; } = new();
+
+		public AssetYamlNode(string key, YAMLScalarNode value)
+		{
+			if (key == "_typelessdata")
+			{
+				//Potentially huge block of data, narrow it down
+				DisplayName = $"{key}: <Byte Array of length {value.Value.Length / 2}>";
+				return;
+			}
+			
+			DisplayName = $"{key}: {value.Value}";
+
+			if (string.IsNullOrEmpty(value.Value))
+				DisplayName += "<Null or Empty Value>";
+		}
+
+		public AssetYamlNode(string key, YAMLMappingNode value)
+		{
+			DisplayName = key;
+			foreach (var (keyNode, valueNode) in value.m_children)
+			{
+				string subKey = keyNode is YAMLScalarNode s ? s.Value : keyNode.ToString()!;
+
+				AppendChild(subKey, valueNode);
+			}
+			
+			if (value.m_children.Count == 0)
+			{
+				DisplayName += ": <Empty Dictionary>";
+			}
+			else
+			{
+				DisplayName += $" (Dictionary with {value.m_children.Count} key{(value.m_children.Count == 1 ? "" : "s")})";
+			}
+		}
+
+		public AssetYamlNode(string key, YAMLSequenceNode value)
+		{
+			DisplayName = key;
+			int i = 0;
+			foreach (var valueNode in value.m_children)
+			{
+				string subKey = $"[{i}]";
+
+				AppendChild(subKey, valueNode);
+
+				i++;
+			}
+
+			if (value.m_children.Count == 0)
+			{
+				DisplayName += ": <Empty Array>";
+			}
+			else
+			{
+				DisplayName += $" (Array of size {value.m_children.Count})";
+			}
+		}
+
+		private void AppendChild(string subKey, YAMLNode valueNode)
+		{
+			AssetYamlNode child;
+			if (valueNode is YAMLScalarNode scalarNode)
+			{
+				child = new AssetYamlNode(subKey, scalarNode);
+			} else if (valueNode is YAMLMappingNode mappingNode)
+			{
+				child = new AssetYamlNode(subKey, mappingNode);
+			} else if (valueNode is YAMLSequenceNode sequenceNode)
+			{
+				child = new AssetYamlNode(subKey, sequenceNode);
+			}
+			else
+			{
+				return;
+			}
+
+			Children.Add(child);
+		}
+	}
+}

--- a/AssetRipperGUI/AssetInfo/SelectedAsset.cs
+++ b/AssetRipperGUI/AssetInfo/SelectedAsset.cs
@@ -1,0 +1,83 @@
+﻿using AssetRipper.Core.Classes;
+using AssetRipper.Core.Classes.GameObject;
+using AssetRipper.Core.Classes.Shader;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
+using System;
+using System.Text;
+using Object = AssetRipper.Core.Classes.Object.Object;
+
+namespace AssetRipper.GUI.AssetInfo
+{
+	public class SelectedAsset
+	{
+		private Object _asset;
+		private readonly string _name;
+
+		public SelectedAsset(Object asset, string name, IExportContainer uiAssetContainer)
+		{
+			_name = name;
+			_asset = asset;
+
+			try
+			{
+				YAMLMappingNode yamlRoot = (YAMLMappingNode)asset.ExportYAML(uiAssetContainer);
+
+				YamlTree = new[] { new AssetYamlNode(Name ?? _asset.GetType().Name, yamlRoot) };
+			}
+			catch (Exception e)
+			{
+				if (e is NotImplementedException or NotSupportedException)
+				{
+					YamlTree = new[] { new AssetYamlNode("Asset Doesn't Support YAML Export", new YAMLScalarNode(true)) };
+					return;
+				}
+				
+				YamlTree = new[] { new AssetYamlNode($"Asset Threw {e.GetType().Name} when exporting as YAML", new YAMLScalarNode(true)) };
+			}
+		}
+
+		public AssetYamlNode[] YamlTree { get; }
+
+		private bool SupportsName => _asset is Shader or GameObject or NamedObject;
+
+		private bool HasName => _asset switch
+		{
+			Shader s => !string.IsNullOrEmpty(s.ValidName),
+			GameObject go => !string.IsNullOrEmpty(go.Name),
+			NamedObject no => !string.IsNullOrEmpty(no.Name),
+			_ => false
+		};
+
+		private string? Name => _asset switch
+		{
+			Shader s => s.ValidName,
+			GameObject go => go.Name,
+			NamedObject no => no.Name,
+			_ => null
+		};
+
+		public string BasicInformation
+		{
+			get
+			{
+				StringBuilder builder = new StringBuilder();
+				builder.Append($"Asset Type: {_asset.GetType()}\n");
+
+				builder.Append($"Supports Name: {SupportsName}\n");
+
+				if (SupportsName)
+				{
+					builder.Append($"Has Name: {HasName}\n");
+
+					if (HasName)
+					{
+						builder.Append($"Name: {Name}\n");
+					}
+				}
+
+				return builder.ToString();
+			}
+		}
+	}
+}

--- a/AssetRipperGUI/AssetRipperGUI.csproj
+++ b/AssetRipperGUI/AssetRipperGUI.csproj
@@ -38,15 +38,15 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="0.10.6"/>
-        <PackageReference Include="Avalonia.Desktop" Version="0.10.6"/>
-        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.6"/>
-        <PackageReference Include="MessageBox.Avalonia" Version="1.5.1"/>
-        <PackageReference Include="System.IO.FileSystem" Version="4.3.0"/>
-        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0"/>
-        <PackageReference Include="System.Security.AccessControl" Version="5.0.0"/>
+        <PackageReference Include="Avalonia" Version="0.10.6" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.6" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.6" />
+        <PackageReference Include="MessageBox.Avalonia" Version="1.5.1" />
+        <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
+        <PackageReference Include="System.Security.AccessControl" Version="5.0.0" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\AssetRipperLibrary\AssetRipperLibrary.csproj"/>
+        <ProjectReference Include="..\AssetRipperLibrary\AssetRipperLibrary.csproj" />
     </ItemGroup>
 </Project>

--- a/AssetRipperGUI/MainWindow.ViewModel.cs
+++ b/AssetRipperGUI/MainWindow.ViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using AssetRipper.Core.Logging;
 using AssetRipper.Core.Project;
 using AssetRipper.Core.Structure.GameStructure;
+using AssetRipper.GUI.AssetInfo;
 using AssetRipper.GUI.Exceptions;
 using AssetRipper.Library;
 using Avalonia.Controls;
@@ -11,6 +12,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using Object = AssetRipper.Core.Classes.Object.Object;
 
 namespace AssetRipper.GUI
 {
@@ -23,12 +25,14 @@ namespace AssetRipper.GUI
 		private string? _loadingText;
 		private string _logText = "";
 		private string _exportingText = "";
+		private SelectedAsset? _selectedAsset;
 
 		public ObservableCollection<NewUiFileListItem> AssetFiles { get; } = new();
 
 		//Not-exposed-to-UI properties
 		private string? _lastExportPath;
-		private readonly  Ripper _ripper = new();
+		private readonly Ripper _ripper = new();
+		private UIAssetContainer _assetContainer;
 
 		public bool HasFile
 		{
@@ -90,6 +94,16 @@ namespace AssetRipper.GUI
 			}
 		}
 
+		public SelectedAsset? SelectedAsset
+		{
+			get => _selectedAsset;
+			set
+			{
+				_selectedAsset = value;
+				OnPropertyChanged();
+			}
+		}
+
 		public MainWindowViewModel()
 		{
 			Logger.Add(new ViewModelLogger(this));
@@ -117,6 +131,7 @@ namespace AssetRipper.GUI
 			}
 
 			_ripper.ResetData();
+			_assetContainer = null;
 
 			string gamePath = filesDropped[0];
 
@@ -129,6 +144,7 @@ namespace AssetRipper.GUI
 			NewUiImportManager.ImportFromPath(_ripper, filesDropped, gameStructure =>
 			{
 				HasLoaded = true;
+				_assetContainer = new UIAssetContainer(_ripper);
 
 				Dispatcher.UIThread.Post(() =>
 				{
@@ -200,6 +216,12 @@ namespace AssetRipper.GUI
 				return;
 
 			DoLoad(new[] { result });
+		}
+
+		public void OnAssetSelected(NewUiFileListItem selectedItem, Object selectedAsset)
+		{
+			_assetContainer.LastAccessedAsset = selectedAsset;
+			SelectedAsset = new SelectedAsset(selectedAsset, selectedItem.DisplayAs, _assetContainer);
 		}
 	}
 }

--- a/AssetRipperGUI/MainWindow.axaml
+++ b/AssetRipperGUI/MainWindow.axaml
@@ -64,7 +64,8 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" MinWidth="800" />
             </Grid.ColumnDefinitions>
-            <TreeView Grid.Column="0" Items="{Binding AssetFiles}">
+            <TreeView Grid.Column="0" Items="{Binding AssetFiles}" SelectionMode="Single"
+                      SelectionChanged="OnAssetSelected">
                 <!--File browser-->
                 <TreeView.ItemTemplate>
                     <TreeDataTemplate ItemsSource="{Binding SubItems}">
@@ -79,8 +80,48 @@
             <Grid Grid.Column="2" RowDefinitions="*, 400">
                 <Grid Grid.Row="0">
                     <!--File content-->
-                    <TextBlock Text="Stuff Coming Soon™️" TextAlignment="Center" VerticalAlignment="Center"
-                               IsVisible="{Binding !IsExporting}" />
+                    
+                    <!--Placeholder for if no asset selected-->
+                    <TextBlock Text="Select an Asset on the left to view information about it" TextAlignment="Center"
+                               VerticalAlignment="Center" FontSize="18">
+                        <TextBlock.IsVisible>
+                            <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                <Binding Path="!IsExporting" />
+                                <Binding Path="HasFile" />
+                                <Binding Path="HasLoaded" />
+                                <Binding Path="SelectedAsset" Converter="{x:Static ObjectConverters.IsNull}" />
+                            </MultiBinding>
+                        </TextBlock.IsVisible>
+                    </TextBlock>
+
+                    <!--Tab list for when an asset is selected-->
+                    <TabControl>
+                        <TabControl.IsVisible>
+                            <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                <Binding Path="!IsExporting" />
+                                <Binding Path="HasFile" />
+                                <Binding Path="HasLoaded" />
+                                <Binding Path="SelectedAsset" Converter="{x:Static ObjectConverters.IsNotNull}" />
+                            </MultiBinding>
+                        </TabControl.IsVisible>
+                        
+                        <!--Basic Info Tab-->
+                        <TabItem Header="Basic Information">
+                            <TextBox Text="{Binding SelectedAsset.BasicInformation, FallbackValue='No Asset Selected'}" />
+                        </TabItem>
+                        
+                        <!--YAML Tab-->
+                        <TabItem Header="YAML Nodes">
+                            <TreeView Items="{Binding SelectedAsset.YamlTree, FallbackValue=[]}">
+                                <TreeView.ItemTemplate>
+                                    <TreeDataTemplate ItemsSource="{Binding Children}">
+                                        <TextBlock Text="{Binding DisplayName}" />
+                                    </TreeDataTemplate>
+                                </TreeView.ItemTemplate>
+                            </TreeView>
+                        </TabItem>
+                        
+                    </TabControl>
 
                     <!--Export Progress-->
                     <TextBlock FontSize="18" Text="{Binding ExportingText}" TextAlignment="Center"

--- a/AssetRipperGUI/MainWindow.axaml.cs
+++ b/AssetRipperGUI/MainWindow.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using System;
+using System.Diagnostics;
 
 namespace AssetRipper.GUI
 {
@@ -44,5 +45,17 @@ namespace AssetRipper.GUI
 	    private void ExitClicked(object? sender, RoutedEventArgs e) => Close();
 
 	    private void ExportAllClicked(object? sender, RoutedEventArgs e) => VM.ExportAll();
+
+	    private void OnAssetSelected(object? sender, SelectionChangedEventArgs e)
+	    {
+		    NewUiFileListItem selectedItem = (NewUiFileListItem) e.AddedItems[0]!;
+		    if (selectedItem.AsObjectAsset == null)
+		    {
+			    //Ignore non-asset files
+			    return;
+		    }
+
+		    VM.OnAssetSelected(selectedItem, selectedItem.AsObjectAsset);
+	    }
     }
 }

--- a/AssetRipperGUI/NewUiFileListing.cs
+++ b/AssetRipperGUI/NewUiFileListing.cs
@@ -2,6 +2,7 @@
 using AssetRipper.Core.Classes.AudioManager;
 using AssetRipper.Core.Classes.EditorBuildSettings;
 using AssetRipper.Core.Classes.EditorSettings;
+using AssetRipper.Core.Classes.GameObject;
 using AssetRipper.Core.Classes.GraphicsSettings;
 using AssetRipper.Core.Classes.InputManager;
 using AssetRipper.Core.Classes.LightmapSettings;
@@ -132,6 +133,9 @@ namespace AssetRipper.GUI
 				OnPropertyChanged();
 			}
 		}
+
+		public Object? AsObjectAsset => _associatedObject; 
+		
 		public ObservableCollection<NewUiFileListItem> SubItems { get; } = new();
 		
 		/// <summary>
@@ -156,10 +160,17 @@ namespace AssetRipper.GUI
 			{
 				_displayAs = no.ValidName;
 			}
-			else
+
+			if (_associatedObject is GameObject go)
+			{
+				_displayAs = go.Name;
+			}
+
+			if (string.IsNullOrEmpty(_displayAs))
 			{
 				_displayAs = _associatedObject.GetType().Name;
 			}
+
 		}
 
 		/// <summary>

--- a/AssetRipperGUI/UIAssetContainer.cs
+++ b/AssetRipperGUI/UIAssetContainer.cs
@@ -1,0 +1,37 @@
+﻿using AssetRipper.Core;
+using AssetRipper.Core.Classes.Object;
+using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Layout;
+using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Parser.Files.SerializedFiles;
+using AssetRipper.Core.Parser.Files.SerializedFiles.Parser;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.Structure.Collections;
+using AssetRipper.Library;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace AssetRipper.GUI
+{
+	public class UIAssetContainer : ProjectAssetContainer
+	{
+
+		public UIAssetContainer(Ripper ripper) : base(
+			ripper.GameStructure.FileCollection.Exporter,
+			ripper.Settings,
+			new VirtualSerializedFile(ripper.GameStructure.FileCollection.Layout),
+			ripper.GameStructure.FileCollection.FetchAssets(),
+			new Collection<IExportCollection>())
+		{
+		}
+		public override IReadOnlyList<FileIdentifier> Dependencies => new List<FileIdentifier>();
+
+		internal Object LastAccessedAsset { get; set; }
+
+		public override ISerializedFile File => LastAccessedAsset.File;
+
+		public override TransferInstructionFlags ExportFlags => ExportLayout.Info.Flags;
+	}
+	
+}


### PR DESCRIPTION
Supports viewing (very) basic information about the asset, i.e. its name and type, and also viewing the YAML export tree.

Handles the case where the asset can't be exported as YAML, or throws an exception, so shouldn't crash the GUI.

Explicitly handles and compacts `_typelessdata` fields (large byte arrays) as they cause huge stutters and can't be parsed meaningfully by a human in text form anyway.

## Preview:
![image](https://user-images.githubusercontent.com/7011721/129384749-2300b3db-3713-40da-8ae8-887204d64a51.png)
