### PR TITLE
Add CMakeLists for building native libraries on non-windows platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Test/
 bin
 *.user
 .idea
+Texture2DDecoderNative/cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ bin
 *.user
 .idea
 Texture2DDecoderNative/cmake-build-debug/
+
+HLSLccWrapper/cmake-build-debug/
+
+HLSLccWrapper/HLSLcc/cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,4 @@ Test/
 bin
 *.user
 .idea
-Texture2DDecoderNative/cmake-build-debug/
-
-HLSLccWrapper/cmake-build-debug/
-
-HLSLccWrapper/HLSLcc/cmake-build-debug/
+**/build/

--- a/HLSLccWrapper/CMakeLists.txt
+++ b/HLSLccWrapper/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.16)
+project(HLSLccWrapper)
+
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(.)
+include_directories(HLSLcc)
+include_directories(HLSLcc/include)
+
+add_library(HLSLccWrapper SHARED
+        HLSLcc/include/growing_array.h
+        HLSLcc/include/hlslcc.h
+        HLSLcc/include/hlslcc.hpp
+        HLSLcc/include/pstdint.h
+        HLSLcc/include/ShaderInfo.h
+        HLSLcc/include/UnityInstancingFlexibleArraySize.h
+        HLSLccWrapper.cpp
+        HLSLccWrapper.h)

--- a/HLSLccWrapper/HLSLcc/CMakeLists.txt
+++ b/HLSLccWrapper/HLSLcc/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.16)
+project(HLSLcc)
+
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(.)
+include_directories(include)
+include_directories(src/)
+include_directories(src/cbstring)
+include_directories(src/internal_includes)
+
+add_library(HLSLcc SHARED
+        include/growing_array.h
+        include/hlslcc.h
+        include/hlslcc.hpp
+        include/pstdint.h
+        include/ShaderInfo.h
+        include/UnityInstancingFlexibleArraySize.h
+        src/cbstring/bsafe.c
+        src/cbstring/bsafe.h
+        src/cbstring/bstraux.c
+        src/cbstring/bstraux.h
+        src/cbstring/bstrlib.c
+        src/cbstring/bstrlib.h
+        src/internal_includes/ControlFlowGraph.h
+        src/internal_includes/ControlFlowGraphUtils.h
+        src/internal_includes/DataTypeAnalysis.h
+        src/internal_includes/debug.h
+        src/internal_includes/Declaration.h
+        src/internal_includes/decode.h
+        src/internal_includes/HLSLccToolkit.h
+        src/internal_includes/HLSLCrossCompilerContext.h
+        src/internal_includes/Instruction.h
+        src/internal_includes/languages.h
+        src/internal_includes/LoopTransform.h
+        src/internal_includes/Operand.h
+        src/internal_includes/reflect.h
+        src/internal_includes/Shader.h
+        src/internal_includes/toGLSL.h
+        src/internal_includes/toGLSLOperand.h
+        src/internal_includes/tokens.h
+        src/internal_includes/toMetal.h
+        src/internal_includes/toMetalDeclaration.h
+        src/internal_includes/Translator.h
+        src/internal_includes/UseDefineChains.h
+        src/ControlFlowGraph.cpp
+        src/ControlFlowGraphUtils.cpp
+        src/DataTypeAnalysis.cpp
+        src/Declaration.cpp
+        src/decode.cpp
+        src/HLSLcc.cpp
+        src/HLSLccToolkit.cpp
+        src/HLSLCrossCompilerContext.cpp
+        src/Instruction.cpp
+        src/LoopTransform.cpp
+        src/Operand.cpp
+        src/reflect.cpp
+        src/Shader.cpp
+        src/ShaderInfo.cpp
+        src/toGLSL.cpp
+        src/toGLSLDeclaration.cpp
+        src/toGLSLInstruction.cpp
+        src/toGLSLOperand.cpp
+        src/toMetal.cpp
+        src/toMetalDeclaration.cpp
+        src/toMetalInstruction.cpp
+        src/toMetalOperand.cpp
+        src/UseDefineChains.cpp)

--- a/Texture2DDecoderNative/CMakeLists.txt
+++ b/Texture2DDecoderNative/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.16)
+project(Texture2DDecoderNative)
+
+set(CMAKE_CXX_STANDARD 14)
+
+# _T2D_DLL;NDEBUG;TEXTURE2DDECODERNATIVE_EXPORTS;_WINDOWS;_USRDLL
+add_compile_definitions(_T2D_DLL)
+add_compile_definitions(NDEBUG)
+add_compile_definitions(TEXTURE2DDECODERNATIVE_EXPORTS)
+
+include_directories(.)
+include_directories(crunch)
+include_directories(fp16)
+include_directories(unitycrunch)
+
+add_library(Texture2DDecoderNative SHARED
+        crunch/crn_decomp.h
+        crunch/crnlib.h
+        fp16/bitcasts.h
+        fp16/fp16.h
+        unitycrunch/crn_decomp.h
+        unitycrunch/crn_defs.h
+        unitycrunch/crnlib.h
+        astc.cpp
+        astc.h
+        atc.cpp
+        atc.h
+        bcn.cpp
+        bcn.h
+        bool32_t.h
+        color.h
+        crunch.cpp
+        crunch.h
+        dllexport.h
+        dllmain.cpp
+        endianness.h
+        etc.cpp
+        etc.h
+        fp16.h
+        pvrtc.cpp
+        pvrtc.h
+        resource.h
+        unitycrunch.cpp
+        unitycrunch.h)

--- a/Texture2DDecoderNative/crunch/crn_decomp.h
+++ b/Texture2DDecoderNative/crunch/crn_decomp.h
@@ -319,6 +319,7 @@ namespace crnd
 #include <memory.h>
 #else
 #include <malloc.h>
+#include <cstring>
 #endif
 #include <stdarg.h>
 #include <new> // needed for placement new, _msize, _expand

--- a/Texture2DDecoderNative/unitycrunch/crn_decomp.h
+++ b/Texture2DDecoderNative/unitycrunch/crn_decomp.h
@@ -21,6 +21,7 @@
 #include <memory.h>
 #else
 #include <malloc.h>
+#include <cstring>
 #endif
 #include <stdarg.h>
 #include <new>  // needed for placement new, _msize, _expand


### PR DESCRIPTION
Build using:
```bash
cd HLSLccWrapper/HLSLcc/
mkdir build
cd build
cmake ..
cmake --build .

cd ../..
mkdir build
cd build
cmake ..
cmake --build .

cd ../..
cd Texture2DDecoderNative
mkdir build
cd build
cmake ..
cmake --build .
```

Produces files (on linux, untested on mac):
```
HLSLccWrapper/HLSLcc/build/libHLSLcc.so
HLSLccWrapper/build/libHLSLccWrapper.so
Texture2DDecoderNative/build/libTexture2DDecoderNative.so
```

Probably not the most optimal setup but it gives you the so files.

Also added two lines to two parts of the Texture 2D Decoder to allow them to build under non-windows platforms.