### PR TITLE
Small GUI Improvements

### DIFF
--- a/AssetRipperGUI/MainWindow.axaml
+++ b/AssetRipperGUI/MainWindow.axaml
@@ -173,7 +173,7 @@
                         </TabItem>
 
                         <!--YAML Tab-->
-                        <TabItem Header="YAML Nodes">
+                        <TabItem Header="YAML Nodes" IsVisible="{Binding SelectedAsset.YamlTreeIsSupported, FallbackValue=False}">
                             <TreeView Items="{Binding SelectedAsset.YamlTree, FallbackValue=[]}">
                                 <TreeView.ItemTemplate>
                                     <TreeDataTemplate ItemsSource="{Binding Children}">


### PR DESCRIPTION
Hide YAML tab for unsupported asset types, show shader data as text.