### PR TITLE
Improvements to detection of serializable fields

### DIFF
--- a/AssetRipperCore/Structure/Assembly/Serializable/SerializableField.cs
+++ b/AssetRipperCore/Structure/Assembly/Serializable/SerializableField.cs
@@ -2,6 +2,7 @@ using AssetRipper.Core.Classes.Misc;
 using AssetRipper.Core.Extensions;
 using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Logging;
 using AssetRipper.Core.Parser.Asset;
 using AssetRipper.Core.Project;
 using AssetRipper.Core.YAML;
@@ -172,6 +173,10 @@ namespace AssetRipper.Core.Structure.Assembly.Serializable
 					if (etalon.IsArray)
 					{
 						int count = reader.ReadInt32();
+
+						if (count > 1_000_000)
+							Logger.Warning($"Unreasonable count for complex array: {count} for field {etalon.Name} of type {etalon.Type}. Probably means there's a bug in serializable detection. Expecting to deadlock here.");
+						
 						IAsset[] structures = new IAsset[count];
 						for (int i = 0; i < count; i++)
 						{


### PR DESCRIPTION
Improves detection of which fields are serializable or not. Leads to more MonoBehaviors having parameters correctly restored, and fixes deadlocks with trying to read arrays of several million (or billion!) elements caused by skipping a field prior to the array, leading to the count int being incorrect.

Also includes a warning which is logged if a complex array has a length > 1,000,000, which should help reproduce future crashes. That limit may need raising in the future - but as most of these fields are manually set via the Unity Editor's UI, I find it very unlikely that any game will have an array of more than a million entries.