### PR TITLE
Add generic write methods to AssetWriter for TypeTreeDumper

### DIFF
--- a/AssetRipperCommon/IO/Asset/AssetWriter.cs
+++ b/AssetRipperCommon/IO/Asset/AssetWriter.cs
@@ -14,8 +14,8 @@ namespace AssetRipper.Core.IO.Asset
 	{
 		private static MethodInfo WritePrimitiveInfo = typeof(AssetWriter).GetMethod(nameof(WritePrimitive));
 		private static MethodInfo WriteAssetInfo = typeof(AssetWriter).GetMethod(nameof(WriteAsset));
-		private static MethodInfo WriteKeyValuePairInfo = typeof(AssetWriter).GetMethod(nameof(WriteKeyValuePair));		
-		private static MethodInfo WriteDictionaryInfo = typeof(AssetWriter).GetMethod(nameof(WriteDictionary));		
+		private static MethodInfo WriteKeyValuePairInfo = typeof(AssetWriter).GetMethod(nameof(WriteKeyValuePair));
+		private static MethodInfo WriteDictionaryInfo = typeof(AssetWriter).GetMethod(nameof(WriteDictionary));
 		private static MethodInfo WriteGenericArrayInfo = typeof(AssetWriter).GetMethods().Single(m => m.Name == nameof(WriteArray) && m.ContainsGenericParameters);
 
 		public AssetWriter(Stream stream, EndianType endian, LayoutInfo info) : base(stream, endian, info.IsAlignArrays)
@@ -72,36 +72,34 @@ namespace AssetRipper.Core.IO.Asset
 
 		public void WritePrimitive<T>(T value) where T : IConvertible
 		{
-			var type = typeof(T);
-
 			//Due to generic optimisations, this method should be reduced down to be very simple.
 			//All the Convert.ToBlah operations should be trivial as T will be the actual type being converted to.
-			if (type == typeof(bool))
-				Write(Convert.ToBoolean(value));
-			else if (type == typeof(byte))
-				Write(Convert.ToByte(value));
-			else if (type == typeof(sbyte))
-				Write(Convert.ToSByte(value));
-			else if (type == typeof(char))
-				Write(Convert.ToChar(value));
-			else if (type == typeof(short))
-				Write(Convert.ToInt16(value));
-			else if (type == typeof(int))
-				Write(Convert.ToInt32(value));
-			else if (type == typeof(long))
-				Write(Convert.ToInt64(value));
-			else if (type == typeof(ushort))
-				Write(Convert.ToUInt16(value));
-			else if (type == typeof(uint))
-				Write(Convert.ToUInt32(value));
-			else if (type == typeof(ulong))
-				Write(Convert.ToUInt64(value));
-			else if (type == typeof(float))
-				Write(Convert.ToSingle(value));
-			else if (type == typeof(double))
-				Write(Convert.ToDouble(value));
+			if (value is bool bo)
+				Write(bo);
+			else if (value is byte b)
+				Write(b);
+			else if (value is sbyte sb)
+				Write(sb);
+			else if (value is char c)
+				Write(c);
+			else if (value is short sh)
+				Write(sh);
+			else if (value is int i)
+				Write(i);
+			else if (value is long lo)
+				Write(lo);
+			else if (value is ushort ush)
+				Write(ush);
+			else if (value is uint ui)
+				Write(ui);
+			else if (value is ulong ulo)
+				Write(ulo);
+			else if (value is float f)
+				Write(f);
+			else if (value is double d)
+				Write(d);
 			else
-				throw new ArgumentException($"Cannot write a primitive of type {type}", nameof(value));
+				throw new ArgumentException($"Cannot write a primitive of type {typeof(T)}", nameof(value));
 		}
 
 		public void WriteAsset<T>(T value) where T : IAssetWritable
@@ -144,10 +142,10 @@ namespace AssetRipper.Core.IO.Asset
 		public void WriteArray<T>(T[] value)
 		{
 			var writer = GetWriter(typeof(T));
-			
+
 			FillInnerBuffer(value.Length);
 			Write(m_buffer, 0, sizeof(int));
-			
+
 			foreach (T nestedValue in value)
 			{
 				writer.Invoke(this, new object[] { nestedValue });
@@ -158,7 +156,7 @@ namespace AssetRipper.Core.IO.Asset
 		{
 			MethodInfo valueWriter = GetWriter<TValue>();
 			MethodInfo keyWriter = GetWriter<TKey>();
-			
+
 			return (keyWriter, valueWriter);
 		}
 
@@ -174,9 +172,9 @@ namespace AssetRipper.Core.IO.Asset
 				return WriteGenericArrayInfo.MakeGenericMethod(type);
 			if (type.FullName!.StartsWith("System.Collections.Generic.KeyValuePair"))
 				return WriteKeyValuePairInfo.MakeGenericMethod(type.GetGenericArguments()[0], type.GetGenericArguments()[1]);
-			if(type.FullName!.StartsWith("System.Collections.Generic.Dictionary"))
+			if (type.FullName!.StartsWith("System.Collections.Generic.Dictionary"))
 				return WriteDictionaryInfo.MakeGenericMethod(type.GetGenericArguments()[0], type.GetGenericArguments()[1]);
-			
+
 			throw new ArgumentException($"Generic Parameter must implement either IConvertible or IAssetWritable, or be an Array, KeyValuePair, or Dictionary for which the parameters also follow this rule. {type} does not.", nameof(type));
 		}
 

--- a/AssetRipperCommon/IO/Asset/AssetWriter.cs
+++ b/AssetRipperCommon/IO/Asset/AssetWriter.cs
@@ -2,14 +2,22 @@
 using AssetRipper.Core.Layout;
 using AssetRipper.Core.Parser.Files;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Text;
-using UnityVersion = AssetRipper.Core.Parser.Files.UnityVersion;
 
 namespace AssetRipper.Core.IO.Asset
 {
 	public sealed class AssetWriter : EndianWriter
 	{
+		private static MethodInfo WritePrimitiveInfo = typeof(AssetWriter).GetMethod(nameof(WritePrimitive));
+		private static MethodInfo WriteAssetInfo = typeof(AssetWriter).GetMethod(nameof(WriteAsset));
+		private static MethodInfo WriteKeyValuePairInfo = typeof(AssetWriter).GetMethod(nameof(WriteKeyValuePair));		
+		private static MethodInfo WriteDictionaryInfo = typeof(AssetWriter).GetMethod(nameof(WriteDictionary));		
+		private static MethodInfo WriteGenericArrayInfo = typeof(AssetWriter).GetMethods().Single(m => m.Name == nameof(WriteArray) && m.ContainsGenericParameters);
+
 		public AssetWriter(Stream stream, EndianType endian, LayoutInfo info) : base(stream, endian, info.IsAlignArrays)
 		{
 			Info = info;
@@ -35,6 +43,7 @@ namespace AssetRipper.Core.IO.Asset
 			{
 				throw new Exception($"Written {written} but expected {count}");
 			}
+
 			Write(buffer, 0, written);
 			if (IsAlignString)
 			{
@@ -53,11 +62,46 @@ namespace AssetRipper.Core.IO.Asset
 				int toWrite = left < BufferSize ? left : BufferSize;
 				for (int i = 0; i < toWrite; i += sizeof(char), index++)
 				{
-					FillInnerBuffer((ushort)buffer[index], i);
+					FillInnerBuffer(buffer[index], i);
 				}
+
 				Write(m_buffer, 0, toWrite);
 				byteIndex += toWrite;
 			}
+		}
+
+		public void WritePrimitive<T>(T value) where T : IConvertible
+		{
+			var type = typeof(T);
+
+			//Due to generic optimisations, this method should be reduced down to be very simple.
+			//All the Convert.ToBlah operations should be trivial as T will be the actual type being converted to.
+			if (type == typeof(bool))
+				Write(Convert.ToBoolean(value));
+			else if (type == typeof(byte))
+				Write(Convert.ToByte(value));
+			else if (type == typeof(sbyte))
+				Write(Convert.ToSByte(value));
+			else if (type == typeof(char))
+				Write(Convert.ToChar(value));
+			else if (type == typeof(short))
+				Write(Convert.ToInt16(value));
+			else if (type == typeof(int))
+				Write(Convert.ToInt32(value));
+			else if (type == typeof(long))
+				Write(Convert.ToInt64(value));
+			else if (type == typeof(ushort))
+				Write(Convert.ToUInt16(value));
+			else if (type == typeof(uint))
+				Write(Convert.ToUInt32(value));
+			else if (type == typeof(ulong))
+				Write(Convert.ToUInt64(value));
+			else if (type == typeof(float))
+				Write(Convert.ToSingle(value));
+			else if (type == typeof(double))
+				Write(Convert.ToDouble(value));
+			else
+				throw new ArgumentException($"Cannot write a primitive of type {type}", nameof(value));
 		}
 
 		public void WriteAsset<T>(T value) where T : IAssetWritable
@@ -74,6 +118,7 @@ namespace AssetRipper.Core.IO.Asset
 			{
 				buffer[i].Write(this);
 			}
+
 			if (IsAlignArray)
 			{
 				AlignStream();
@@ -89,10 +134,78 @@ namespace AssetRipper.Core.IO.Asset
 			{
 				WriteAssetArray(buffer[i]);
 			}
+
 			if (IsAlignArray)
 			{
 				AlignStream();
 			}
+		}
+
+		public void WriteArray<T>(T[] value)
+		{
+			var writer = GetWriter(typeof(T));
+			
+			FillInnerBuffer(value.Length);
+			Write(m_buffer, 0, sizeof(int));
+			
+			foreach (T nestedValue in value)
+			{
+				writer.Invoke(this, new object[] { nestedValue });
+			}
+		}
+
+		private static (MethodInfo keyWriter, MethodInfo valueWriter) GetKeyAndValueWriter<TKey, TValue>()
+		{
+			MethodInfo valueWriter = GetWriter<TValue>();
+			MethodInfo keyWriter = GetWriter<TKey>();
+			
+			return (keyWriter, valueWriter);
+		}
+
+		private static MethodInfo GetWriter<T>() => GetWriter(typeof(T));
+
+		private static MethodInfo GetWriter(Type type)
+		{
+			if (type.IsAssignableTo(typeof(IConvertible)))
+				return WritePrimitiveInfo.MakeGenericMethod(type);
+			if (type.IsAssignableTo(typeof(IAssetWritable)))
+				return WriteAssetInfo.MakeGenericMethod(type);
+			if (type.IsArray)
+				return WriteGenericArrayInfo.MakeGenericMethod(type);
+			if (type.FullName!.StartsWith("System.Collections.Generic.KeyValuePair"))
+				return WriteKeyValuePairInfo.MakeGenericMethod(type.GetGenericArguments()[0], type.GetGenericArguments()[1]);
+			if(type.FullName!.StartsWith("System.Collections.Generic.Dictionary"))
+				return WriteDictionaryInfo.MakeGenericMethod(type.GetGenericArguments()[0], type.GetGenericArguments()[1]);
+			
+			throw new ArgumentException($"Generic Parameter must implement either IConvertible or IAssetWritable, or be an Array, KeyValuePair, or Dictionary for which the parameters also follow this rule. {type} does not.", nameof(type));
+		}
+
+		public void WriteKeyValuePair<TKey, TValue>(KeyValuePair<TKey, TValue> pair)
+		{
+			(MethodInfo keyWriter, MethodInfo valueWriter) = GetKeyAndValueWriter<TKey, TValue>();
+
+			keyWriter.Invoke(this, new object[] { pair.Key });
+			valueWriter.Invoke(this, new object[] { pair.Value });
+		}
+
+		public void WriteDictionary<TKey, TValue>(Dictionary<TKey, TValue> dict)
+		{
+			(MethodInfo keyWriter, MethodInfo valueWriter) = GetKeyAndValueWriter<TKey, TValue>();
+
+			FillInnerBuffer(dict.Count);
+			Write(m_buffer, 0, sizeof(int));
+
+			foreach (var (key, value) in dict)
+			{
+				keyWriter.Invoke(this, new object[] { key });
+				valueWriter.Invoke(this, new object[] { value });
+			}
+		}
+
+		public void WriteGeneric<T>(T value)
+		{
+			var writer = GetWriter<T>();
+			writer.Invoke(this, new object[] { value });
 		}
 
 		public LayoutInfo Info { get; }


### PR DESCRIPTION
Adds a WriteGeneric<T> to AssetWriter to make code generation for AssemblyDumper simpler.

It handles KeyValuePairs, Dictionaries, Arrays, and any combinations of all of those, as well as primitives and IAssetWritables.