### PR TITLE
Fix `OverflowException` in `MeshHelper.BytesToFloatArray`

### DIFF
--- a/AssetRipperCore/Classes/Mesh/MeshHelper.cs
+++ b/AssetRipperCore/Classes/Mesh/MeshHelper.cs
@@ -160,7 +160,7 @@ namespace AssetRipper.Core.Classes.Mesh
 						result[i] = inputBytes[i] / 255f;
 						break;
 					case VertexFormat.kVertexFormatSNorm8:
-						result[i] = System.Math.Max((sbyte)inputBytes[i] / 127f, -1f);
+						result[i] = System.Math.Max(unchecked((sbyte)inputBytes[i]) / 127f, -1f);
 						break;
 					case VertexFormat.kVertexFormatUNorm16:
 						result[i] = BitConverter.ToUInt16(inputBytes, i * 2) / 65535f;


### PR DESCRIPTION
This PR fixed a possible error in mesh reading, that caused by the use of checked conversion operation from `byte` to `sbyte`.
See https://github.com/ds5678/AssetRipper/blob/fa7f0dbbaf20976a92d211e17f34703dece3b1d6/AssetRipperCore/Classes/Mesh/MeshHelper.cs#L163
Note that `(sbyte)inputBytes[i]` will throw an `OverflowException` when the byte is greater than 127, which i do think is unintended.

<details><summary>exception log</summary>
<p>


```
Message: Error during reading of asset type Mesh
Inner: System.OverflowException: Arithmetic operation resulted in an overflow.
   at AssetRipper.Core.Classes.Mesh.MeshHelper.BytesToFloatArray(Byte[] inputBytes, VertexFormat format) in D:\a\AssetRipper\AssetRipper\AssetRipperCore\Classes\Mesh\MeshHelper.cs:line 142
   at AssetRipper.Core.Classes.Mesh.Mesh.ReadVertexData(UnityVersion version) in D:\a\AssetRipper\AssetRipper\AssetRipperCore\Classes\Mesh\Mesh.cs:line 1069
   at AssetRipper.Core.Classes.Mesh.Mesh.ProcessData(UnityVersion version) in D:\a\AssetRipper\AssetRipper\AssetRipperCore\Classes\Mesh\Mesh.cs:line 998
   at AssetRipper.Core.Classes.Mesh.Mesh.Read(AssetReader reader) in D:\a\AssetRipper\AssetRipper\AssetRipperCore\Classes\Mesh\Mesh.cs:line 574
   at AssetRipper.Core.Parser.Files.SerializedFiles.SerializedFile.ReadAsset(AssetReader reader, AssetInfo assetInfo, Int64 offset, Int32 size) in D:\a\AssetRipper\AssetRipper\AssetRipperCommon\Parser\Files\SerializedFile\SerializedFile.cs:line 331
StackTrace:    at AssetRipper.Core.Parser.Files.SerializedFiles.SerializedFile.ReadAsset(AssetReader reader, AssetInfo assetInfo, Int64 offset, Int32 size) in D:\a\AssetRipper\AssetRipper\AssetRipperCommon\Parser\Files\SerializedFile\SerializedFile.cs:line 335
   at AssetRipper.Core.Parser.Files.SerializedFiles.SerializedFile.ReadAsset(AssetReader reader, ObjectInfo& info) in D:\a\AssetRipper\AssetRipper\AssetRipperCommon\Parser\Files\SerializedFile\SerializedFile.cs:line 313
   at AssetRipper.Core.Parser.Files.SerializedFiles.SerializedFile.ReadData(Stream stream) in D:\a\AssetRipper\AssetRipper\AssetRipperCommon\Parser\Files\SerializedFile\SerializedFile.cs:line 262
   at AssetRipper.Core.Structure.GameStructure.GameProcessorContext.ReadFile(SerializedFile file) in D:\a\AssetRipper\AssetRipper\AssetRipperCommon\Structure\GameStructure\GameProcessorContext.cs:line 38
   at AssetRipper.Core.Structure.GameStructure.GameProcessorContext.ReadFile(SerializedFile file) in D:\a\AssetRipper\AssetRipper\AssetRipperCommon\Structure\GameStructure\GameProcessorContext.cs:line 44
   at AssetRipper.Core.Structure.GameStructure.GameProcessorContext.ReadSerializedFiles() in D:\a\AssetRipper\AssetRipper\AssetRipperCommon\Structure\GameStructure\GameProcessorContext.cs:line 30
   at AssetRipper.Core.Structure.GameStructure.GameStructureProcessor.ProcessSchemes(GameCollection fileCollection) in D:\a\AssetRipper\AssetRipper\AssetRipperCommon\Structure\GameStructure\GameStructureProcessor.cs:line 92
   at AssetRipper.Core.Structure.GameStructure.GameStructure.Load(List`1 paths, CoreConfiguration configuration, LayoutInfo layinfo) in D:\a\AssetRipper\AssetRipper\AssetRipperCore\Structure\GameStructure\GameStructure.cs:line 80
   at AssetRipper.Core.Structure.GameStructure.GameStructure.Load(IEnumerable`1 paths, CoreConfiguration configuration, LayoutInfo layinfo) in D:\a\AssetRipper\AssetRipper\AssetRipperCore\Structure\GameStructure\GameStructure.cs:line 40
   at AssetRipper.Core.Structure.GameStructure.GameStructure.Load(IEnumerable`1 paths, CoreConfiguration configuration) in D:\a\AssetRipper\AssetRipper\AssetRipperCore\Structure\GameStructure\GameStructure.cs:line 32
   at AssetRipper.Library.Ripper.Load(IReadOnlyList`1 paths) in D:\a\AssetRipper\AssetRipper\AssetRipperLibrary\Ripper.cs:line 103
   at AssetRipper.GUI.Managers.UIImportManager.ImportFromPathInternal(Ripper ripper, String[] paths, Action`1 onComplete, Action`1 onError) in D:\a\AssetRipper\AssetRipper\AssetRipperGUI\Managers\UIImportManager.cs:line 24

```

</p>
</details>